### PR TITLE
feat: geo_filter polygon overlay on map and live pages (Go backend)

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -47,12 +47,23 @@ type Config struct {
 	Retention *RetentionConfig `json:"retention,omitempty"`
 
 	PacketStore *PacketStoreConfig `json:"packetStore,omitempty"`
+
+	GeoFilter *GeoFilterConfig `json:"geo_filter,omitempty"`
 }
 
 // PacketStoreConfig controls in-memory packet store limits.
 type PacketStoreConfig struct {
 	RetentionHours float64 `json:"retentionHours"` // max age of packets in hours (0 = unlimited)
 	MaxMemoryMB    int     `json:"maxMemoryMB"`     // hard memory ceiling in MB (0 = unlimited)
+}
+
+type GeoFilterConfig struct {
+	Polygon  [][2]float64 `json:"polygon,omitempty"`
+	BufferKm float64      `json:"bufferKm,omitempty"`
+	LatMin   *float64     `json:"latMin,omitempty"`
+	LatMax   *float64     `json:"latMax,omitempty"`
+	LonMin   *float64     `json:"lonMin,omitempty"`
+	LonMax   *float64     `json:"lonMax,omitempty"`
 }
 
 type RetentionConfig struct {

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -102,6 +102,7 @@ func (s *Server) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/config/regions", s.handleConfigRegions).Methods("GET")
 	r.HandleFunc("/api/config/theme", s.handleConfigTheme).Methods("GET")
 	r.HandleFunc("/api/config/map", s.handleConfigMap).Methods("GET")
+	r.HandleFunc("/api/config/geo-filter", s.handleConfigGeoFilter).Methods("GET")
 
 	// System endpoints
 	r.HandleFunc("/api/health", s.handleHealth).Methods("GET")
@@ -308,6 +309,15 @@ func (s *Server) handleConfigMap(w http.ResponseWriter, r *http.Request) {
 		zoom = 9
 	}
 	writeJSON(w, MapConfigResponse{Center: center, Zoom: zoom})
+}
+
+func (s *Server) handleConfigGeoFilter(w http.ResponseWriter, r *http.Request) {
+	gf := s.cfg.GeoFilter
+	if gf == nil || len(gf.Polygon) == 0 {
+		writeJSON(w, map[string]interface{}{"polygon": nil, "bufferKm": 0})
+		return
+	}
+	writeJSON(w, map[string]interface{}{"polygon": gf.Polygon, "bufferKm": gf.BufferKm})
 }
 
 // --- System Handlers ---

--- a/cmd/server/routes_test.go
+++ b/cmd/server/routes_test.go
@@ -2064,7 +2064,7 @@ func TestConfigGeoFilterEndpoint(t *testing.T) {
 		}
 		hub := NewHub()
 		srv := NewServer(db, cfg, hub)
-		srv.store = NewPacketStore(db)
+		srv.store = NewPacketStore(db, nil)
 		srv.store.Load()
 		router := mux.NewRouter()
 		srv.RegisterRoutes(router)

--- a/cmd/server/routes_test.go
+++ b/cmd/server/routes_test.go
@@ -2033,6 +2033,60 @@ func TestObserverAnalyticsNoStore(t *testing.T) {
 		t.Fatalf("expected 503, got %d", w.Code)
 	}
 }
+func TestConfigGeoFilterEndpoint(t *testing.T) {
+	t.Run("no geo filter configured", func(t *testing.T) {
+		_, router := setupTestServer(t)
+		req := httptest.NewRequest("GET", "/api/config/geo-filter", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var body map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &body)
+		if body["polygon"] != nil {
+			t.Errorf("expected polygon to be nil when no geo filter configured, got %v", body["polygon"])
+		}
+	})
+
+	t.Run("with polygon configured", func(t *testing.T) {
+		db := setupTestDB(t)
+		seedTestData(t, db)
+		lat0, lat1 := 50.0, 51.5
+		lon0, lon1 := 3.0, 5.5
+		cfg := &Config{
+			Port: 3000,
+			GeoFilter: &GeoFilterConfig{
+				Polygon:  [][2]float64{{lat0, lon0}, {lat1, lon0}, {lat1, lon1}, {lat0, lon1}},
+				BufferKm: 20,
+			},
+		}
+		hub := NewHub()
+		srv := NewServer(db, cfg, hub)
+		srv.store = NewPacketStore(db)
+		srv.store.Load()
+		router := mux.NewRouter()
+		srv.RegisterRoutes(router)
+
+		req := httptest.NewRequest("GET", "/api/config/geo-filter", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var body map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &body)
+		if body["polygon"] == nil {
+			t.Error("expected polygon in response when geo filter is configured")
+		}
+		if body["bufferKm"] == nil {
+			t.Error("expected bufferKm in response")
+		}
+	})
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/public/geo-filter-overlay.js
+++ b/public/geo-filter-overlay.js
@@ -1,0 +1,56 @@
+// Shared helper — initialises the geo-filter polygon overlay on a Leaflet map.
+// Returns the L.layerGroup (or null if no filter is configured / fetch fails).
+// The returned layer is added to the map when the checkbox is toggled on, and
+// removed when toggled off.  The toggle state is persisted in localStorage
+// under the key 'meshcore-map-geo-filter'.
+//
+// Parameters:
+//   map        – Leaflet map instance
+//   checkboxId – id of the <input type="checkbox"> that controls visibility
+//   labelId    – id of the <label> wrapper to reveal once data is loaded
+async function initGeoFilterOverlay(map, checkboxId, labelId) {
+  try {
+    const gf = await api('/config/geo-filter', { ttl: 3600 });
+    if (!gf || !gf.polygon || gf.polygon.length < 3) return null;
+
+    const latlngs = gf.polygon.map(function (p) { return [p[0], p[1]]; });
+    const innerPoly = L.polygon(latlngs, {
+      color: '#3b82f6', weight: 2, opacity: 0.8,
+      fillColor: '#3b82f6', fillOpacity: 0.08
+    });
+
+    const bufferPoly = gf.bufferKm > 0 ? (function () {
+      let cLat = 0, cLon = 0;
+      gf.polygon.forEach(function (p) { cLat += p[0]; cLon += p[1]; });
+      cLat /= gf.polygon.length; cLon /= gf.polygon.length;
+      const cosLat = Math.cos(cLat * Math.PI / 180);
+      const outer = gf.polygon.map(function (p) {
+        const dLatM = (p[0] - cLat) * 111000;
+        const dLonM = (p[1] - cLon) * 111000 * cosLat;
+        const dist = Math.sqrt(dLatM * dLatM + dLonM * dLonM);
+        if (dist === 0) return [p[0], p[1]];
+        const scale = (gf.bufferKm * 1000) / dist;
+        return [p[0] + dLatM * scale / 111000, p[1] + dLonM * scale / (111000 * cosLat)];
+      });
+      return L.polygon(outer, {
+        color: '#3b82f6', weight: 1.5, opacity: 0.4, dashArray: '6 4',
+        fillColor: '#3b82f6', fillOpacity: 0.04
+      });
+    })() : null;
+
+    const layer = L.layerGroup(bufferPoly ? [bufferPoly, innerPoly] : [innerPoly]);
+
+    const label = document.getElementById(labelId);
+    if (label) label.style.display = '';
+    const el = document.getElementById(checkboxId);
+    if (el) {
+      const saved = localStorage.getItem('meshcore-map-geo-filter');
+      if (saved === 'true') { el.checked = true; layer.addTo(map); }
+      el.addEventListener('change', function (e) {
+        localStorage.setItem('meshcore-map-geo-filter', e.target.checked);
+        if (e.target.checked) { layer.addTo(map); } else { map.removeLayer(layer); }
+      });
+    }
+    return layer;
+  } catch (e) { return null; }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -90,6 +90,7 @@
   <script src="home.js?v=1774786038"></script>
   <script src="packet-filter.js?v=1774786038"></script>
   <script src="packets.js?v=1774786038"></script>
+  <script src="geo-filter-overlay.js?v=1774786038"></script>
   <script src="map.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
   <script src="channels.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
   <script src="nodes.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>

--- a/public/live.js
+++ b/public/live.js
@@ -5,7 +5,7 @@
   function cssVar(name) { return getComputedStyle(document.documentElement).getPropertyValue(name).trim(); }
   function statusGreen() { return cssVar('--status-green') || '#22c55e'; }
 
-  let map, ws, nodesLayer, pathsLayer, animLayer, heatLayer;
+  let map, ws, nodesLayer, pathsLayer, animLayer, heatLayer, geoFilterLayer;
   let nodeMarkers = {};
   let nodeData = {};
   let packetCount = 0;
@@ -658,6 +658,7 @@
             <span id="audioDesc" class="sr-only">Sonify packets — turn raw bytes into generative music</span>
             <label><input type="checkbox" id="liveFavoritesToggle" aria-describedby="favDesc"> ⭐ Favorites</label>
             <span id="favDesc" class="sr-only">Show only favorited and claimed nodes</span>
+            <label id="liveGeoFilterLabel" style="display:none"><input type="checkbox" id="liveGeoFilterToggle"> Mesh live area</label>
           </div>
           <div class="audio-controls hidden" id="audioControls">
             <label class="audio-slider-label">Voice <select id="audioVoiceSelect" class="audio-voice-select"></select></label>
@@ -800,6 +801,49 @@
       localStorage.setItem('live-favorites-only', showOnlyFavorites);
       applyFavoritesFilter();
     });
+
+    // Geo filter overlay
+    (async function () {
+      try {
+        const gf = await api('/config/geo-filter', { ttl: 3600 });
+        if (!gf || !gf.polygon || gf.polygon.length < 3) return;
+        const latlngs = gf.polygon.map(function (p) { return [p[0], p[1]]; });
+        const innerPoly = L.polygon(latlngs, {
+          color: '#3b82f6', weight: 2, opacity: 0.8,
+          fillColor: '#3b82f6', fillOpacity: 0.08
+        });
+        const bufferPoly = gf.bufferKm > 0 ? (function () {
+          let cLat = 0, cLon = 0;
+          gf.polygon.forEach(function (p) { cLat += p[0]; cLon += p[1]; });
+          cLat /= gf.polygon.length; cLon /= gf.polygon.length;
+          const cosLat = Math.cos(cLat * Math.PI / 180);
+          const outer = gf.polygon.map(function (p) {
+            const dLatM = (p[0] - cLat) * 111000;
+            const dLonM = (p[1] - cLon) * 111000 * cosLat;
+            const dist = Math.sqrt(dLatM * dLatM + dLonM * dLonM);
+            if (dist === 0) return [p[0], p[1]];
+            const scale = (gf.bufferKm * 1000) / dist;
+            return [p[0] + dLatM * scale / 111000, p[1] + dLonM * scale / (111000 * cosLat)];
+          });
+          return L.polygon(outer, {
+            color: '#3b82f6', weight: 1.5, opacity: 0.4, dashArray: '6 4',
+            fillColor: '#3b82f6', fillOpacity: 0.04
+          });
+        })() : null;
+        geoFilterLayer = L.layerGroup(bufferPoly ? [bufferPoly, innerPoly] : [innerPoly]);
+        const label = document.getElementById('liveGeoFilterLabel');
+        if (label) label.style.display = '';
+        const el = document.getElementById('liveGeoFilterToggle');
+        if (el) {
+          const saved = localStorage.getItem('meshcore-map-geo-filter');
+          if (saved === 'true') { el.checked = true; geoFilterLayer.addTo(map); }
+          el.addEventListener('change', function (e) {
+            localStorage.setItem('meshcore-map-geo-filter', e.target.checked);
+            if (e.target.checked) { geoFilterLayer.addTo(map); } else { map.removeLayer(geoFilterLayer); }
+          });
+        }
+      } catch (e) { /* no geo filter configured */ }
+    })();
 
     const matrixToggle = document.getElementById('liveMatrixToggle');
     matrixToggle.checked = matrixMode;
@@ -2431,7 +2475,7 @@
       }
       _navCleanup = null;
     }
-    nodesLayer = pathsLayer = animLayer = heatLayer = null;
+    nodesLayer = pathsLayer = animLayer = heatLayer = geoFilterLayer = null;
     stopMatrixRain();
     nodeMarkers = {}; nodeData = {};
     recentPaths = [];

--- a/public/live.js
+++ b/public/live.js
@@ -803,47 +803,7 @@
     });
 
     // Geo filter overlay
-    (async function () {
-      try {
-        const gf = await api('/config/geo-filter', { ttl: 3600 });
-        if (!gf || !gf.polygon || gf.polygon.length < 3) return;
-        const latlngs = gf.polygon.map(function (p) { return [p[0], p[1]]; });
-        const innerPoly = L.polygon(latlngs, {
-          color: '#3b82f6', weight: 2, opacity: 0.8,
-          fillColor: '#3b82f6', fillOpacity: 0.08
-        });
-        const bufferPoly = gf.bufferKm > 0 ? (function () {
-          let cLat = 0, cLon = 0;
-          gf.polygon.forEach(function (p) { cLat += p[0]; cLon += p[1]; });
-          cLat /= gf.polygon.length; cLon /= gf.polygon.length;
-          const cosLat = Math.cos(cLat * Math.PI / 180);
-          const outer = gf.polygon.map(function (p) {
-            const dLatM = (p[0] - cLat) * 111000;
-            const dLonM = (p[1] - cLon) * 111000 * cosLat;
-            const dist = Math.sqrt(dLatM * dLatM + dLonM * dLonM);
-            if (dist === 0) return [p[0], p[1]];
-            const scale = (gf.bufferKm * 1000) / dist;
-            return [p[0] + dLatM * scale / 111000, p[1] + dLonM * scale / (111000 * cosLat)];
-          });
-          return L.polygon(outer, {
-            color: '#3b82f6', weight: 1.5, opacity: 0.4, dashArray: '6 4',
-            fillColor: '#3b82f6', fillOpacity: 0.04
-          });
-        })() : null;
-        geoFilterLayer = L.layerGroup(bufferPoly ? [bufferPoly, innerPoly] : [innerPoly]);
-        const label = document.getElementById('liveGeoFilterLabel');
-        if (label) label.style.display = '';
-        const el = document.getElementById('liveGeoFilterToggle');
-        if (el) {
-          const saved = localStorage.getItem('meshcore-map-geo-filter');
-          if (saved === 'true') { el.checked = true; geoFilterLayer.addTo(map); }
-          el.addEventListener('change', function (e) {
-            localStorage.setItem('meshcore-map-geo-filter', e.target.checked);
-            if (e.target.checked) { geoFilterLayer.addTo(map); } else { map.removeLayer(geoFilterLayer); }
-          });
-        }
-      } catch (e) { /* no geo filter configured */ }
-    })();
+    initGeoFilterOverlay(map, 'liveGeoFilterToggle', 'liveGeoFilterLabel').then(function (layer) { geoFilterLayer = layer; });
 
     const matrixToggle = document.getElementById('liveMatrixToggle');
     matrixToggle.checked = matrixMode;

--- a/public/map.js
+++ b/public/map.js
@@ -12,6 +12,7 @@
   let filters = { repeater: true, companion: true, room: true, sensor: true, observer: true, lastHeard: '30d', neighbors: false, clusters: false, hashLabels: localStorage.getItem('meshcore-map-hash-labels') !== 'false', statusFilter: localStorage.getItem('meshcore-map-status-filter') || 'all' };
   let wsHandler = null;
   let heatLayer = null;
+  let geoFilterLayer = null;
   let userHasMoved = false;
   let controlsCollapsed = false;
 
@@ -94,6 +95,7 @@
             <label for="mcClusters"><input type="checkbox" id="mcClusters"> Show clusters</label>
             <label for="mcHeatmap"><input type="checkbox" id="mcHeatmap"> Heat map</label>
             <label for="mcHashLabels"><input type="checkbox" id="mcHashLabels"> Hash prefix labels</label>
+            <label for="mcGeoFilter" id="mcGeoFilterLabel" style="display:none"><input type="checkbox" id="mcGeoFilter"> Geo filter area</label>
           </fieldset>
           <fieldset class="mc-section">
             <legend class="mc-label">Status</legend>

--- a/public/map.js
+++ b/public/map.js
@@ -226,48 +226,7 @@
     });
 
     // Geo filter overlay
-    (async function () {
-      try {
-        const gf = await api('/config/geo-filter', { ttl: 3600 });
-        if (!gf || !gf.polygon || gf.polygon.length < 3) return;
-        const latlngs = gf.polygon.map(function (p) { return [p[0], p[1]]; });
-        const innerPoly = L.polygon(latlngs, {
-          color: '#3b82f6', weight: 2, opacity: 0.8,
-          fillColor: '#3b82f6', fillOpacity: 0.08
-        });
-        // Approximate buffer zone — expand each vertex outward from centroid by bufferKm
-        const bufferPoly = gf.bufferKm > 0 ? (function () {
-          let cLat = 0, cLon = 0;
-          gf.polygon.forEach(function (p) { cLat += p[0]; cLon += p[1]; });
-          cLat /= gf.polygon.length; cLon /= gf.polygon.length;
-          const cosLat = Math.cos(cLat * Math.PI / 180);
-          const outer = gf.polygon.map(function (p) {
-            const dLatM = (p[0] - cLat) * 111000;
-            const dLonM = (p[1] - cLon) * 111000 * cosLat;
-            const dist = Math.sqrt(dLatM * dLatM + dLonM * dLonM);
-            if (dist === 0) return [p[0], p[1]];
-            const scale = (gf.bufferKm * 1000) / dist;
-            return [p[0] + dLatM * scale / 111000, p[1] + dLonM * scale / (111000 * cosLat)];
-          });
-          return L.polygon(outer, {
-            color: '#3b82f6', weight: 1.5, opacity: 0.4, dashArray: '6 4',
-            fillColor: '#3b82f6', fillOpacity: 0.04
-          });
-        })() : null;
-        geoFilterLayer = L.layerGroup(bufferPoly ? [bufferPoly, innerPoly] : [innerPoly]);
-        const label = document.getElementById('mcGeoFilterLabel');
-        if (label) label.style.display = '';
-        const el = document.getElementById('mcGeoFilter');
-        if (el) {
-          const saved = localStorage.getItem('meshcore-map-geo-filter');
-          if (saved === 'true') { el.checked = true; geoFilterLayer.addTo(map); }
-          el.addEventListener('change', function (e) {
-            localStorage.setItem('meshcore-map-geo-filter', e.target.checked);
-            if (e.target.checked) { geoFilterLayer.addTo(map); } else { map.removeLayer(geoFilterLayer); }
-          });
-        }
-      } catch (e) { /* no geo filter configured */ }
-    })();
+    initGeoFilterOverlay(map, 'mcGeoFilter', 'mcGeoFilterLabel').then(function (layer) { geoFilterLayer = layer; });
 
     // WS for live advert updates
     wsHandler = debouncedOnWS(function (msgs) {
@@ -771,6 +730,7 @@
     markerLayer = null;
     routeLayer = null;
     if (heatLayer) { heatLayer = null; }
+    geoFilterLayer = null;
   }
 
   function toggleHeatmap(on) {

--- a/public/map.js
+++ b/public/map.js
@@ -225,6 +225,50 @@
       });
     });
 
+    // Geo filter overlay
+    (async function () {
+      try {
+        const gf = await api('/config/geo-filter', { ttl: 3600 });
+        if (!gf || !gf.polygon || gf.polygon.length < 3) return;
+        const latlngs = gf.polygon.map(function (p) { return [p[0], p[1]]; });
+        const innerPoly = L.polygon(latlngs, {
+          color: '#3b82f6', weight: 2, opacity: 0.8,
+          fillColor: '#3b82f6', fillOpacity: 0.08
+        });
+        // Approximate buffer zone — expand each vertex outward from centroid by bufferKm
+        const bufferPoly = gf.bufferKm > 0 ? (function () {
+          let cLat = 0, cLon = 0;
+          gf.polygon.forEach(function (p) { cLat += p[0]; cLon += p[1]; });
+          cLat /= gf.polygon.length; cLon /= gf.polygon.length;
+          const cosLat = Math.cos(cLat * Math.PI / 180);
+          const outer = gf.polygon.map(function (p) {
+            const dLatM = (p[0] - cLat) * 111000;
+            const dLonM = (p[1] - cLon) * 111000 * cosLat;
+            const dist = Math.sqrt(dLatM * dLatM + dLonM * dLonM);
+            if (dist === 0) return [p[0], p[1]];
+            const scale = (gf.bufferKm * 1000) / dist;
+            return [p[0] + dLatM * scale / 111000, p[1] + dLonM * scale / (111000 * cosLat)];
+          });
+          return L.polygon(outer, {
+            color: '#3b82f6', weight: 1.5, opacity: 0.4, dashArray: '6 4',
+            fillColor: '#3b82f6', fillOpacity: 0.04
+          });
+        })() : null;
+        geoFilterLayer = L.layerGroup(bufferPoly ? [bufferPoly, innerPoly] : [innerPoly]);
+        const label = document.getElementById('mcGeoFilterLabel');
+        if (label) label.style.display = '';
+        const el = document.getElementById('mcGeoFilter');
+        if (el) {
+          const saved = localStorage.getItem('meshcore-map-geo-filter');
+          if (saved === 'true') { el.checked = true; geoFilterLayer.addTo(map); }
+          el.addEventListener('change', function (e) {
+            localStorage.setItem('meshcore-map-geo-filter', e.target.checked);
+            if (e.target.checked) { geoFilterLayer.addTo(map); } else { map.removeLayer(geoFilterLayer); }
+          });
+        }
+      } catch (e) { /* no geo filter configured */ }
+    })();
+
     // WS for live advert updates
     wsHandler = debouncedOnWS(function (msgs) {
       if (msgs.some(function (m) { return m.type === 'packet' && m.data?.decoded?.header?.payloadTypeName === 'ADVERT'; })) {


### PR DESCRIPTION
## Summary

- Adds `GeoFilter` struct to `Config` in `cmd/server/config.go` so `geo_filter.polygon` and `bufferKm` from `config.json` are parsed by the Go backend
- Adds `GET /api/config/geo-filter` endpoint in `cmd/server/routes.go` returning the polygon + bufferKm to the frontend
- Restores the blue polygon overlay (solid inner + dashed buffer zone) on the **Map** page (`public/map.js`)
- Restores the same overlay on the **Live** page (`public/live.js`), toggled via the "Mesh live area" checkbox

## Test plan

- [x] `GET /api/config/geo-filter` returns `{ polygon: [...], bufferKm: N }` when configured
- [x] `GET /api/config/geo-filter` returns `{ polygon: null, bufferKm: 0 }` when not configured
- [x] Map page shows blue polygon overlay when `geo_filter.polygon` is set in config
- [x] Live page shows same overlay, checkbox state shared via localStorage
- [x] Checkbox is hidden when no polygon is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)