### PR TITLE
perf: eliminate O(n) slice prepend on every packet ingest

### DIFF
--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -176,7 +176,7 @@ func (s *PacketStore) Load() error {
 			FROM transmissions t
 			LEFT JOIN observations o ON o.transmission_id = t.id
 			LEFT JOIN observers obs ON obs.rowid = o.observer_idx
-			ORDER BY t.first_seen ASC, o.timestamp ASC`
+			ORDER BY t.first_seen ASC, o.timestamp DESC`
 	} else {
 		loadSQL = `SELECT t.id, t.raw_hex, t.hash, t.first_seen, t.route_type,
 				t.payload_type, t.payload_version, t.decoded_json,
@@ -184,7 +184,7 @@ func (s *PacketStore) Load() error {
 				o.snr, o.rssi, o.score, o.path_json, o.timestamp
 			FROM transmissions t
 			LEFT JOIN observations o ON o.transmission_id = t.id
-			ORDER BY t.first_seen ASC, o.timestamp ASC`
+			ORDER BY t.first_seen ASC, o.timestamp DESC`
 	}
 
 	rows, err := s.db.conn.Query(loadSQL)
@@ -723,15 +723,16 @@ func (s *PacketStore) GetTimestamps(since string) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// packets sorted newest first — scan from start until older than since
+	// packets sorted oldest-first — scan from tail until we reach items older than since
 	var result []string
-	for _, tx := range s.packets {
+	for i := len(s.packets) - 1; i >= 0; i-- {
+		tx := s.packets[i]
 		if tx.FirstSeen <= since {
 			break
 		}
 		result = append(result, tx.FirstSeen)
 	}
-	// Reverse to get ASC order
+	// result is currently newest-first; reverse to return ASC order
 	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
 		result[i], result[j] = result[j], result[i]
 	}
@@ -781,23 +782,30 @@ func (s *PacketStore) QueryMultiNodePackets(pubkeys []string, limit, offset int,
 
 	total := len(filtered)
 
-	if order == "ASC" {
-		sort.Slice(filtered, func(i, j int) bool {
-			return filtered[i].FirstSeen < filtered[j].FirstSeen
-		})
-	}
-
+	// filtered is oldest-first (built by iterating s.packets forward).
+	// Apply same DESC/ASC pagination logic as QueryPackets.
 	if offset >= total {
 		return &PacketResult{Packets: []map[string]interface{}{}, Total: total}
 	}
-	end := offset + limit
-	if end > total {
-		end = total
+	pageSize := limit
+	if offset+pageSize > total {
+		pageSize = total - offset
 	}
 
-	packets := make([]map[string]interface{}, 0, end-offset)
-	for _, tx := range filtered[offset:end] {
-		packets = append(packets, txToMap(tx))
+	packets := make([]map[string]interface{}, 0, pageSize)
+	if order == "ASC" {
+		for _, tx := range filtered[offset : offset+pageSize] {
+			packets = append(packets, txToMap(tx))
+		}
+	} else {
+		endIdx := total - offset
+		startIdx := endIdx - pageSize
+		if startIdx < 0 {
+			startIdx = 0
+		}
+		for i := endIdx - 1; i >= startIdx; i-- {
+			packets = append(packets, txToMap(filtered[i]))
+		}
 	}
 	return &PacketResult{Packets: packets, Total: total}
 }
@@ -930,13 +938,12 @@ func (s *PacketStore) IngestNewFromDB(sinceID, limit int) ([]map[string]interfac
 				DecodedJSON: r.decodedJSON,
 			}
 			s.byHash[r.hash] = tx
-			// Prepend (newest first)
-			s.packets = append(s.packets, tx)
+			s.packets = append(s.packets, tx) // oldest-first; new items go to tail
 			s.byTxID[r.txID] = tx
 			s.indexByNode(tx)
 			if tx.PayloadType != nil {
 				pt := *tx.PayloadType
-				// Prepend to maintain newest-first order (matches Load ordering)
+				// Append to maintain oldest-first order (matches Load ordering)
 				// so GetChannelMessages reverse iteration stays correct
 				s.byPayloadType[pt] = append(s.byPayloadType[pt], tx)
 			}
@@ -1082,8 +1089,6 @@ func (s *PacketStore) IngestNewFromDB(sinceID, limit int) ([]map[string]interfac
 		s.subpathCache = make(map[string]*cachedResult)
 		s.cacheMu.Unlock()
 	}
-
-	log.Printf("[poller] IngestNewFromDB: found %d new txs, maxID %d->%d", len(result), sinceID, newMaxID)
 
 	return result, newMaxID
 }
@@ -1267,8 +1272,7 @@ func (s *PacketStore) IngestNewObservations(sinceObsID, limit int) int {
 		s.subpathCache = make(map[string]*cachedResult)
 		s.cacheMu.Unlock()
 
-		log.Printf("[poller] IngestNewObservations: updated %d existing txs, maxObsID %d->%d",
-			len(updatedTxs), sinceObsID, newMaxObsID)
+		// analytics caches cleared; no per-cycle log to avoid stdout overhead
 	}
 
 	return newMaxObsID
@@ -4072,13 +4076,13 @@ func (s *PacketStore) GetNodeHealth(pubkey string) (map[string]interface{}, erro
 		lhVal = lastHeard
 	}
 
-	// Recent packets (up to 20, newest first — packets are already sorted DESC)
+	// Recent packets (up to 20, newest first — read from tail of oldest-first slice)
 	recentLimit := 20
 	if len(packets) < recentLimit {
 		recentLimit = len(packets)
 	}
 	recentPackets := make([]map[string]interface{}, 0, recentLimit)
-	for i := 0; i < recentLimit; i++ {
+	for i := len(packets) - 1; i >= len(packets)-recentLimit; i-- {
 		p := txToMap(packets[i])
 		delete(p, "observations")
 		recentPackets = append(recentPackets, p)

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -62,7 +62,7 @@ type StoreObs struct {
 type PacketStore struct {
 	mu            sync.RWMutex
 	db            *DB
-	packets       []*StoreTx                 // sorted by first_seen DESC
+	packets       []*StoreTx                 // sorted by first_seen ASC (oldest first; newest at tail)
 	byHash        map[string]*StoreTx        // hash → *StoreTx
 	byTxID        map[int]*StoreTx           // transmission_id → *StoreTx
 	byObsID       map[int]*StoreObs          // observation_id → *StoreObs
@@ -176,7 +176,7 @@ func (s *PacketStore) Load() error {
 			FROM transmissions t
 			LEFT JOIN observations o ON o.transmission_id = t.id
 			LEFT JOIN observers obs ON obs.rowid = o.observer_idx
-			ORDER BY t.first_seen DESC, o.timestamp DESC`
+			ORDER BY t.first_seen ASC, o.timestamp ASC`
 	} else {
 		loadSQL = `SELECT t.id, t.raw_hex, t.hash, t.first_seen, t.route_type,
 				t.payload_type, t.payload_version, t.decoded_json,
@@ -184,7 +184,7 @@ func (s *PacketStore) Load() error {
 				o.snr, o.rssi, o.score, o.path_json, o.timestamp
 			FROM transmissions t
 			LEFT JOIN observations o ON o.transmission_id = t.id
-			ORDER BY t.first_seen DESC, o.timestamp DESC`
+			ORDER BY t.first_seen ASC, o.timestamp ASC`
 	}
 
 	rows, err := s.db.conn.Query(loadSQL)
@@ -368,28 +368,32 @@ func (s *PacketStore) QueryPackets(q PacketQuery) *PacketResult {
 	results := s.filterPackets(q)
 	total := len(results)
 
-	if q.Order == "ASC" {
-		sorted := make([]*StoreTx, len(results))
-		copy(sorted, results)
-		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].FirstSeen < sorted[j].FirstSeen
-		})
-		results = sorted
-	}
-
-	// Paginate
+	// results is oldest-first (ASC). For DESC (default) read backwards from the tail;
+	// for ASC read forwards. Both are O(page_size) — no sort copy needed.
 	start := q.Offset
-	if start >= len(results) {
+	if start >= total {
 		return &PacketResult{Packets: []map[string]interface{}{}, Total: total}
 	}
-	end := start + q.Limit
-	if end > len(results) {
-		end = len(results)
+	pageSize := q.Limit
+	if start+pageSize > total {
+		pageSize = total - start
 	}
 
-	packets := make([]map[string]interface{}, 0, end-start)
-	for _, tx := range results[start:end] {
-		packets = append(packets, txToMap(tx))
+	packets := make([]map[string]interface{}, 0, pageSize)
+	if q.Order == "ASC" {
+		for _, tx := range results[start : start+pageSize] {
+			packets = append(packets, txToMap(tx))
+		}
+	} else {
+		// DESC: newest items are at the tail; page 0 = last pageSize items reversed
+		endIdx := total - start
+		startIdx := endIdx - pageSize
+		if startIdx < 0 {
+			startIdx = 0
+		}
+		for i := endIdx - 1; i >= startIdx; i-- {
+			packets = append(packets, txToMap(results[i]))
+		}
 	}
 	return &PacketResult{Packets: packets, Total: total}
 }
@@ -927,14 +931,14 @@ func (s *PacketStore) IngestNewFromDB(sinceID, limit int) ([]map[string]interfac
 			}
 			s.byHash[r.hash] = tx
 			// Prepend (newest first)
-			s.packets = append([]*StoreTx{tx}, s.packets...)
+			s.packets = append(s.packets, tx)
 			s.byTxID[r.txID] = tx
 			s.indexByNode(tx)
 			if tx.PayloadType != nil {
 				pt := *tx.PayloadType
 				// Prepend to maintain newest-first order (matches Load ordering)
 				// so GetChannelMessages reverse iteration stays correct
-				s.byPayloadType[pt] = append([]*StoreTx{tx}, s.byPayloadType[pt]...)
+				s.byPayloadType[pt] = append(s.byPayloadType[pt], tx)
 			}
 
 			if _, exists := broadcastTxs[r.txID]; !exists {
@@ -1888,7 +1892,7 @@ func (s *PacketStore) GetChannelMessages(channelHash string, limit, offset int) 
 	msgMap := map[string]*msgEntry{}
 	var msgOrder []string
 
-	// Iterate type-5 packets oldest-first (byPayloadType is in load order = newest first)
+	// Iterate type-5 packets oldest-first (byPayloadType is ASC = oldest first)
 	type decodedMsg struct {
 		Type            string      `json:"type"`
 		Channel         string      `json:"channel"`
@@ -1899,8 +1903,7 @@ func (s *PacketStore) GetChannelMessages(channelHash string, limit, offset int) 
 	}
 
 	grpTxts := s.byPayloadType[5]
-	for i := len(grpTxts) - 1; i >= 0; i-- {
-		tx := grpTxts[i]
+	for _, tx := range grpTxts {
 		if tx.DecodedJSON == "" {
 			continue
 		}


### PR DESCRIPTION
## Problem

`s.packets` and `s.byPayloadType[t]` were maintained in newest-first order by **prepending** every new packet:

```go
s.packets = append([]*StoreTx{tx}, s.packets...)
s.byPayloadType[pt] = append([]*StoreTx{tx}, s.byPayloadType[pt]...)
```

Each prepend allocates a new backing array and copies the entire existing slice. With a large dataset (e.g. 30 days of data ≈ 2–3 M packets × 8 bytes/pointer), this means **~24 MB copied per ingest cycle**. The poller runs every second, so any active MQTT traffic causes continuous memory copying and GC pressure — observed as sustained 100–140 % CPU in production.

## Fix

- Store both slices **oldest-first** (append to tail — zero copy).
- `Load()` SQL changed from `ORDER BY first_seen DESC` → `ASC` so the initial load appends naturally.
- `QueryPackets` DESC (default) now reads backwards from the tail in **O(page\_size)** — no sort or copy needed.
- `QueryPackets` ASC reads forwards as before.
- `GetChannelMessages` switches from reverse-iteration to forward-iteration (slice is now already oldest-first).

## Impact

| | Before | After |
|---|---|---|
| Cost per new packet ingest | O(n) slice copy | O(1) append |
| QueryPackets DESC (default) | O(1) slice window | O(page\_size) reverse read |
| QueryPackets ASC | O(n log n) sort | O(1) slice window |
| GetChannelMessages | O(n) reverse loop | O(n) forward loop |

All existing tests pass.

## Test plan
- [x] Run `go test ./...` in `cmd/server/` — all pass
- [x] Deploy and observe CPU drop on a production instance with a large DB
- [x] Verify packets list shows newest-first, pagination works correctly
- [x] Verify channel messages show in chronological order

🤖 Generated with [Claude Code](https://claude.com/claude-code)