### PR TITLE
fix: round Go Runtime floats to 1dp, prevent nav stats dot wrapping

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,9 +22,9 @@
   <meta name="twitter:title" content="CoreScope">
   <meta name="twitter:description" content="Real-time MeshCore LoRa mesh network analyzer — live packet visualization, node tracking, channel decryption, and route analysis.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Kpa-clawbot/corescope/master/public/og-image.png">
-  <link rel="stylesheet" href="style.css?v=1774731523">
-  <link rel="stylesheet" href="home.css?v=1774731523">
-  <link rel="stylesheet" href="live.css?v=1774731523">
+  <link rel="stylesheet" href="style.css?v=1774786038">
+  <link rel="stylesheet" href="home.css?v=1774786038">
+  <link rel="stylesheet" href="live.css?v=1774786038">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
     crossorigin="anonymous">
@@ -81,29 +81,29 @@
   <main id="app" role="main"></main>
 
   <script src="vendor/qrcode.js"></script>
-  <script src="roles.js?v=1774731523"></script>
-  <script src="customize.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="region-filter.js?v=1774731523"></script>
-  <script src="hop-resolver.js?v=1774731523"></script>
-  <script src="hop-display.js?v=1774731523"></script>
-  <script src="app.js?v=1774731523"></script>
-  <script src="home.js?v=1774731523"></script>
-  <script src="packet-filter.js?v=1774731523"></script>
-  <script src="packets.js?v=1774731523"></script>
-  <script src="map.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="channels.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="nodes.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="traces.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="analytics.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-v1-constellation.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-v2-constellation.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-lab.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="live.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="observers.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="observer-detail.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="compare.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="node-analytics.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="perf.js?v=1774731523" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="roles.js?v=1774786038"></script>
+  <script src="customize.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="region-filter.js?v=1774786038"></script>
+  <script src="hop-resolver.js?v=1774786038"></script>
+  <script src="hop-display.js?v=1774786038"></script>
+  <script src="app.js?v=1774786038"></script>
+  <script src="home.js?v=1774786038"></script>
+  <script src="packet-filter.js?v=1774786038"></script>
+  <script src="packets.js?v=1774786038"></script>
+  <script src="map.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="channels.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="nodes.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="traces.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="analytics.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-v1-constellation.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-v2-constellation.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-lab.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="live.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="observers.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="observer-detail.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="compare.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="node-analytics.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="perf.js?v=1774786038" onerror="console.error('Failed to load:', this.src)"></script>
 </body>
 </html>

--- a/public/perf.js
+++ b/public/perf.js
@@ -40,12 +40,12 @@
           html += `<h3>🔧 Go Runtime</h3><div style="display:flex;gap:16px;flex-wrap:wrap;margin:8px 0;">
             <div class="perf-card"><div class="perf-num">${gr.goroutines}</div><div class="perf-label">Goroutines</div></div>
             <div class="perf-card"><div class="perf-num">${gr.numGC}</div><div class="perf-label">GC Collections</div></div>
-            <div class="perf-card"><div class="perf-num" style="color:${gcColor}">${gr.pauseTotalMs}ms</div><div class="perf-label">GC Pause Total</div></div>
-            <div class="perf-card"><div class="perf-num">${gr.lastPauseMs}ms</div><div class="perf-label">Last GC Pause</div></div>
-            <div class="perf-card"><div class="perf-num">${gr.heapAllocMB}MB</div><div class="perf-label">Heap Alloc</div></div>
-            <div class="perf-card"><div class="perf-num">${gr.heapSysMB}MB</div><div class="perf-label">Heap Sys</div></div>
-            <div class="perf-card"><div class="perf-num">${gr.heapInuseMB}MB</div><div class="perf-label">Heap Inuse</div></div>
-            <div class="perf-card"><div class="perf-num">${gr.heapIdleMB}MB</div><div class="perf-label">Heap Idle</div></div>
+            <div class="perf-card"><div class="perf-num" style="color:${gcColor}">${(+gr.pauseTotalMs).toFixed(1)}ms</div><div class="perf-label">GC Pause Total</div></div>
+            <div class="perf-card"><div class="perf-num">${(+gr.lastPauseMs).toFixed(1)}ms</div><div class="perf-label">Last GC Pause</div></div>
+            <div class="perf-card"><div class="perf-num">${(+gr.heapAllocMB).toFixed(1)}MB</div><div class="perf-label">Heap Alloc</div></div>
+            <div class="perf-card"><div class="perf-num">${(+gr.heapSysMB).toFixed(1)}MB</div><div class="perf-label">Heap Sys</div></div>
+            <div class="perf-card"><div class="perf-num">${(+gr.heapInuseMB).toFixed(1)}MB</div><div class="perf-label">Heap Inuse</div></div>
+            <div class="perf-card"><div class="perf-num">${(+gr.heapIdleMB).toFixed(1)}MB</div><div class="perf-label">Heap Idle</div></div>
             <div class="perf-card"><div class="perf-num">${gr.numCPU}</div><div class="perf-label">CPUs</div></div>
             <div class="perf-card"><div class="perf-num">${health.websocket.clients}</div><div class="perf-label">WS Clients</div></div>
           </div>`;

--- a/public/style.css
+++ b/public/style.css
@@ -155,7 +155,7 @@ a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible
 /* === Nav Stats === */
 .nav-stats {
   display: flex; gap: 12px; align-items: center; font-size: 12px; color: var(--nav-text-muted);
-  font-family: var(--mono); margin-right: 4px;
+  font-family: var(--mono); margin-right: 4px; white-space: nowrap;
 }
 .nav-stats .stat-val { color: var(--nav-text); font-weight: 600; transition: color 0.3s ease; }
 .nav-stats .stat-val.updated { color: var(--accent); }


### PR DESCRIPTION
## Summary

- **perf.js**: All Go Runtime ms/MB values now use `toFixed(1)` — fixes values like `1052.6516952514648MB` showing as `1052.7MB`
- **style.css**: `white-space: nowrap` on `.nav-stats` — fixes the `·` separator between pkts/nodes/obs wrapping onto its own line

## Screenshots

Before: `1052.6516952514648MB`, `144.862217ms`, nav dots wrapping to new line  
After: `1052.7MB`, `144.9ms`, single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)