### PR TITLE
fix: use dominant (most common) hash size instead of last-seen

### DIFF
--- a/cmd/server/routes_test.go
+++ b/cmd/server/routes_test.go
@@ -2003,6 +2003,49 @@ t.Error("expected inconsistent flag to be true for flip-flop pattern")
 }
 }
 
+func TestGetNodeHashSizeInfoDominant(t *testing.T) {
+// A node that sends mostly 2-byte adverts but occasionally 1-byte (pathByte=0x00
+// on direct sends) should report HashSize=2, not 1.
+db := setupTestDB(t)
+seedTestData(t, db)
+store := NewPacketStore(db, nil)
+if err := store.Load(); err != nil {
+	t.Fatalf("store.Load failed: %v", err)
+}
+
+pk := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+db.conn.Exec("INSERT OR IGNORE INTO nodes (public_key, name, role) VALUES (?, 'Repeater2B', 'repeater')", pk)
+
+decoded := `{"name":"Repeater2B","pubKey":"` + pk + `"}`
+raw1byte := "04" + "00" + "aabb" // pathByte=0x00 → hashSize=1 (direct send, no hops)
+raw2byte := "04" + "40" + "aabb" // pathByte=0x40 → hashSize=2
+
+payloadType := 4
+// 1 packet with hashSize=1, 4 packets with hashSize=2
+raws := []string{raw1byte, raw2byte, raw2byte, raw2byte, raw2byte}
+for i, raw := range raws {
+	tx := &StoreTx{
+		ID:          8000 + i,
+		RawHex:      raw,
+		Hash:        "dominant" + strconv.Itoa(i),
+		FirstSeen:   "2024-01-01T00:00:00Z",
+		PayloadType: &payloadType,
+		DecodedJSON: decoded,
+	}
+	store.packets = append(store.packets, tx)
+	store.byPayloadType[4] = append(store.byPayloadType[4], tx)
+}
+
+info := store.GetNodeHashSizeInfo()
+ni := info[pk]
+if ni == nil {
+	t.Fatal("expected hash info for test node")
+}
+if ni.HashSize != 2 {
+	t.Errorf("HashSize=%d, want 2 (dominant size should win over occasional 1-byte)", ni.HashSize)
+}
+}
+
 func TestAnalyticsHashSizesNoNullArrays(t *testing.T) {
 _, router := setupTestServer(t)
 req := httptest.NewRequest("GET", "/api/analytics/hash-sizes", nil)

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -4067,14 +4067,32 @@ func (s *PacketStore) computeNodeHashSizeInfo() map[string]*hashSizeNodeInfo {
 			ni = &hashSizeNodeInfo{AllSizes: make(map[int]bool)}
 			info[pk] = ni
 		}
-		ni.HashSize = hs
 		ni.AllSizes[hs] = true
 		ni.Seq = append(ni.Seq, hs)
 	}
 
-	// Compute flip-flop (inconsistent) flag: need >= 3 observations,
-	// >= 2 unique sizes, and >= 2 transitions in the sequence.
+	// Post-process: compute dominant hash size (mode) and flip-flop flag.
+	// Using the last-seen value would misreport nodes that occasionally send
+	// with pathByte=0x00 (hashSize=1) when transmitting directly with no
+	// relay hops, even though their true hash size is 2 or 3.
 	for _, ni := range info {
+		// Dominant hash size: pick the most frequently observed size.
+		// On a tie, prefer the larger value (more specific).
+		counts := make(map[int]int, len(ni.AllSizes))
+		for _, hs := range ni.Seq {
+			counts[hs]++
+		}
+		best, bestCount := 1, 0
+		for hs, cnt := range counts {
+			if cnt > bestCount || (cnt == bestCount && hs > best) {
+				best = hs
+				bestCount = cnt
+			}
+		}
+		ni.HashSize = best
+
+		// Flip-flop (inconsistent) flag: need >= 3 observations,
+		// >= 2 unique sizes, and >= 2 transitions in the sequence.
 		if len(ni.Seq) < 3 || len(ni.AllSizes) < 2 {
 			continue
 		}


### PR DESCRIPTION
## Problem

Repeaters with 2-byte adverts occasionally appear as 1-byte on the map and in stats.

**Root cause:** `computeNodeHashSizeInfo()` sets `HashSize` by overwriting on every packet (`ni.HashSize = hs`), so the last advert processed wins — regardless of how many previous packets correctly showed 2-byte.

When a node sends an ADVERT directly (no relay hops), the path byte encodes `hashCount=0`. Some firmware sets the full path byte to `0x00` in this case, which decodes as `hashSize=1` even if the node normally uses 2-byte hashes. If this packet happens to be the last one iterated, the node shows as 1-byte.

## Fix

Compute the **mode** (most frequent hash size) across all observed adverts instead of using the last-seen value. On a tie, prefer the larger value.

```go
counts := make(map[int]int, len(ni.AllSizes))
for _, hs := range ni.Seq {
    counts[hs]++
}
best, bestCount := 1, 0
for hs, cnt := range counts {
    if cnt > bestCount || (cnt == bestCount && hs > best) {
        best = hs
        bestCount = cnt
    }
}
ni.HashSize = best
```

A node with 4× hashSize=2 and 1× hashSize=1 now correctly reports `HashSize=2`.

## Test

`TestGetNodeHashSizeInfoDominant`: seeds 5 adverts (4× 2-byte, 1× 1-byte) and asserts `HashSize=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)