### PR TITLE
fix: VCR timeline and clock respect UTC/local timezone setting

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,9 +22,9 @@
   <meta name="twitter:title" content="CoreScope">
   <meta name="twitter:description" content="Real-time MeshCore LoRa mesh network analyzer — live packet visualization, node tracking, channel decryption, and route analysis.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Kpa-clawbot/corescope/master/public/og-image.png">
-  <link rel="stylesheet" href="style.css?v=1775062162">
-  <link rel="stylesheet" href="home.css?v=1775062162">
-  <link rel="stylesheet" href="live.css?v=1775062162">
+  <link rel="stylesheet" href="style.css?v=1775073838">
+  <link rel="stylesheet" href="home.css?v=1775073838">
+  <link rel="stylesheet" href="live.css?v=1775073838">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
     crossorigin="anonymous">
@@ -85,30 +85,30 @@
   <main id="app" role="main"></main>
 
   <script src="vendor/qrcode.js"></script>
-  <script src="roles.js?v=1775062162"></script>
-  <script src="customize.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="region-filter.js?v=1775062162"></script>
-  <script src="hop-resolver.js?v=1775062162"></script>
-  <script src="hop-display.js?v=1775062162"></script>
-  <script src="app.js?v=1775062162"></script>
-  <script src="home.js?v=1775062162"></script>
-  <script src="packet-filter.js?v=1775062162"></script>
-  <script src="packets.js?v=1775062162"></script>
-  <script src="geo-filter-overlay.js?v=1775062162"></script>
-  <script src="map.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="channels.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="nodes.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="traces.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="analytics.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-v1-constellation.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-v2-constellation.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-lab.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="live.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="observers.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="observer-detail.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="compare.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="node-analytics.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="perf.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="roles.js?v=1775073838"></script>
+  <script src="customize.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="region-filter.js?v=1775073838"></script>
+  <script src="hop-resolver.js?v=1775073838"></script>
+  <script src="hop-display.js?v=1775073838"></script>
+  <script src="app.js?v=1775073838"></script>
+  <script src="home.js?v=1775073838"></script>
+  <script src="packet-filter.js?v=1775073838"></script>
+  <script src="packets.js?v=1775073838"></script>
+  <script src="geo-filter-overlay.js?v=1775073838"></script>
+  <script src="map.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="channels.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="nodes.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="traces.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="analytics.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-v1-constellation.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-v2-constellation.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-lab.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="live.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="observers.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="observer-detail.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="compare.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="node-analytics.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="perf.js?v=1775073838" onerror="console.error('Failed to load:', this.src)"></script>
 </body>
 </html>

--- a/public/live.js
+++ b/public/live.js
@@ -368,12 +368,17 @@
     }
   }
 
-  function updateVCRClock(tsMs) {
+  function vcrFormatTime(tsMs) {
     const d = new Date(tsMs);
-    const hh = String(d.getHours()).padStart(2, '0');
-    const mm = String(d.getMinutes()).padStart(2, '0');
-    const ss = String(d.getSeconds()).padStart(2, '0');
-    drawLcdText(`${hh}:${mm}:${ss}`, statusGreen());
+    const utc = typeof getTimestampTimezone === 'function' && getTimestampTimezone() === 'utc';
+    const hh = String(utc ? d.getUTCHours() : d.getHours()).padStart(2, '0');
+    const mm = String(utc ? d.getUTCMinutes() : d.getMinutes()).padStart(2, '0');
+    const ss = String(utc ? d.getUTCSeconds() : d.getSeconds()).padStart(2, '0');
+    return `${hh}:${mm}:${ss}`;
+  }
+
+  function updateVCRClock(tsMs) {
+    drawLcdText(vcrFormatTime(tsMs), statusGreen());
   }
 
   function updateVCRLcd() {
@@ -1060,8 +1065,7 @@
       const rect = timelineEl.getBoundingClientRect();
       const pct = (e.clientX - rect.left) / rect.width;
       const ts = Date.now() - VCR.timelineScope + pct * VCR.timelineScope;
-      const d = new Date(ts);
-      timeTooltip.textContent = d.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+      timeTooltip.textContent = vcrFormatTime(ts);
       timeTooltip.style.left = (e.clientX - rect.left) + 'px';
       timeTooltip.classList.remove('hidden');
     });
@@ -1074,8 +1078,7 @@
       const rect = timelineEl.getBoundingClientRect();
       const pct = Math.max(0, Math.min(1, (touch.clientX - rect.left) / rect.width));
       const ts = Date.now() - VCR.timelineScope + pct * VCR.timelineScope;
-      const d = new Date(ts);
-      timeTooltip.textContent = d.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+      timeTooltip.textContent = vcrFormatTime(ts);
       timeTooltip.style.left = (touch.clientX - rect.left) + 'px';
       timeTooltip.classList.remove('hidden');
     });
@@ -1581,6 +1584,7 @@
   window._livePruneStaleNodes = pruneStaleNodes;
   window._liveNodeMarkers = function() { return nodeMarkers; };
   window._liveNodeData = function() { return nodeData; };
+  window._vcrFormatTime = vcrFormatTime;
 
   async function replayRecent() {
     try {

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -966,6 +966,66 @@ console.log('\n=== live.js: pruneStaleNodes ===');
   });
 }
 
+// ===== live.js: vcrFormatTime respects UTC/local setting =====
+console.log('\n=== live.js: vcrFormatTime UTC/local ===');
+{
+  function makeLiveSandboxForVcr() {
+    const ctx = makeSandbox();
+    ctx.L = { map: () => ({ on: () => {}, setView: () => {}, addLayer: () => {}, remove: () => {} }), tileLayer: () => ({ addTo: () => {} }), layerGroup: () => ({ addTo: () => {}, clearLayers: () => {}, addLayer: () => {} }), circleMarker: () => ({ addTo: () => {}, remove: () => {}, setStyle: () => {}, getLatLng: () => ({}), on: () => {} }), Polyline: function() { return { addTo: () => {}, remove: () => {} }; }, Control: { extend: () => function() { return { addTo: () => {} }; } } };
+    ctx.Chart = function() { return { destroy: () => {}, update: () => {} }; };
+    ctx.navigator = {};
+    ctx.visualViewport = null;
+    ctx.document.documentElement = { getAttribute: () => null, setAttribute: () => {} };
+    ctx.document.body = { appendChild: () => {}, removeChild: () => {}, contains: () => false };
+    ctx.document.querySelector = () => null;
+    ctx.document.querySelectorAll = () => [];
+    ctx.document.createElementNS = () => ctx.document.createElement();
+    ctx.cancelAnimationFrame = () => {};
+    ctx.IATA_COORDS_GEO = {};
+    loadInCtx(ctx, 'public/roles.js');
+    try { loadInCtx(ctx, 'public/live.js'); } catch (e) {
+      for (const k of Object.keys(ctx.window)) ctx[k] = ctx.window[k];
+    }
+    return ctx;
+  }
+
+  test('vcrFormatTime is exposed as window._vcrFormatTime', () => {
+    const ctx = makeLiveSandboxForVcr();
+    assert.strictEqual(typeof ctx.window._vcrFormatTime, 'function', '_vcrFormatTime must be exposed');
+  });
+
+  test('vcrFormatTime uses UTC hours when timezone is utc', () => {
+    const ctx = makeLiveSandboxForVcr();
+    const fn = ctx.window._vcrFormatTime;
+    assert.ok(fn, '_vcrFormatTime must be exposed');
+    // Force UTC mode
+    ctx.getTimestampTimezone = () => 'utc';
+    // Use a known timestamp: 2024-01-15 14:30:45 UTC = different local time in most zones
+    const tsMs = Date.UTC(2024, 0, 15, 14, 30, 45);
+    const result = fn(tsMs);
+    assert.strictEqual(result, '14:30:45', 'UTC mode must show UTC hours 14:30:45');
+  });
+
+  test('vcrFormatTime uses local hours when timezone is local', () => {
+    const ctx = makeLiveSandboxForVcr();
+    const fn = ctx.window._vcrFormatTime;
+    assert.ok(fn, '_vcrFormatTime must be exposed');
+    ctx.getTimestampTimezone = () => 'local';
+    const d = new Date(2024, 0, 15, 9, 5, 3); // local time
+    const expected = String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0') + ':' + String(d.getSeconds()).padStart(2,'0');
+    assert.strictEqual(fn(d.getTime()), expected, 'local mode must use local hours');
+  });
+
+  test('vcrFormatTime zero-pads single-digit hours, minutes, seconds', () => {
+    const ctx = makeLiveSandboxForVcr();
+    const fn = ctx.window._vcrFormatTime;
+    assert.ok(fn, '_vcrFormatTime must be exposed');
+    ctx.getTimestampTimezone = () => 'utc';
+    const tsMs = Date.UTC(2024, 0, 15, 3, 5, 7); // 03:05:07 UTC
+    assert.strictEqual(fn(tsMs), '03:05:07');
+  });
+}
+
 // ===== NODES.JS: isAdvertMessage + auto-update logic =====
 console.log('\n=== nodes.js: isAdvertMessage ===');
 {


### PR DESCRIPTION
## Problem

Fixes #324. The VCR LCD clock and timeline hover/touch tooltip always showed local time, ignoring the UTC/local timezone setting in the customizer Display tab.

## Root cause

Three sites in `live.js` bypassed the shared `getTimestampTimezone()` utility:

- `updateVCRClock()` — used `d.getHours()` / `d.getMinutes()` / `d.getSeconds()` (always local)
- Timeline mousemove tooltip — used `d.toLocaleTimeString()` (always local)
- Timeline touchmove tooltip — same

## Fix

Added `vcrFormatTime(tsMs)` helper that checks `getTimestampTimezone()` and uses `getUTC*` methods when set to `'utc'`, otherwise local `get*`. Applied to all three sites. Exposed as `window._vcrFormatTime` for testing.

## Tests

4 new unit tests in `test-frontend-helpers.js` covering UTC mode, local mode, and zero-padding.

## Checklist
- [x] Branches from `upstream/master`
- [x] No Matomo or local-only commits
- [x] Cache busters bumped (`v=1775073838`)
- [x] 233 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)