### PR TITLE
fix: reset restores home steps after SITE_CONFIG contamination

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -807,6 +807,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // User's localStorage preferences take priority over server config
     const userTheme = (() => { try { return JSON.parse(localStorage.getItem('meshcore-user-theme') || '{}'); } catch { return {}; } })();
+    window._SITE_CONFIG_ORIGINAL_HOME = JSON.parse(JSON.stringify(window.SITE_CONFIG.home || {}));
     mergeUserHomeConfig(window.SITE_CONFIG, userTheme);
 
     // Apply CSS variable overrides from theme config (skipped if user has local overrides)

--- a/public/customize.js
+++ b/public/customize.js
@@ -450,7 +450,8 @@
     function mergeSection(key) {
       return Object.assign({}, DEFAULTS[key], cfg[key] || {}, local[key] || {});
     }
-    var mergedHome = mergeSection('home');
+    var serverHome = window._SITE_CONFIG_ORIGINAL_HOME || cfg.home || {};
+    var mergedHome = Object.assign({}, DEFAULTS.home, serverHome, local.home || {});
     var localTsMode = localStorage.getItem('meshcore-timestamp-mode');
     var localTsTimezone = localStorage.getItem('meshcore-timestamp-timezone');
     var localTsFormat = localStorage.getItem('meshcore-timestamp-format');
@@ -1202,19 +1203,19 @@
         var tmp = state.home.steps[i];
         state.home.steps[i] = state.home.steps[j];
         state.home.steps[j] = tmp;
-        render(container);
+        render(container); autoSave();
       });
     });
     container.querySelectorAll('[data-rm-step]').forEach(function (btn) {
       btn.addEventListener('click', function () {
         state.home.steps.splice(parseInt(btn.dataset.rmStep), 1);
-        render(container);
+        render(container); autoSave();
       });
     });
     var addStepBtn = document.getElementById('addStep');
     if (addStepBtn) addStepBtn.addEventListener('click', function () {
       state.home.steps.push({ emoji: '📌', title: '', description: '' });
-      render(container);
+      render(container); autoSave();
     });
 
     // Checklist
@@ -1227,13 +1228,13 @@
     container.querySelectorAll('[data-rm-check]').forEach(function (btn) {
       btn.addEventListener('click', function () {
         state.home.checklist.splice(parseInt(btn.dataset.rmCheck), 1);
-        render(container);
+        render(container); autoSave();
       });
     });
     var addCheckBtn = document.getElementById('addCheck');
     if (addCheckBtn) addCheckBtn.addEventListener('click', function () {
       state.home.checklist.push({ question: '', answer: '' });
-      render(container);
+      render(container); autoSave();
     });
 
     // Footer links
@@ -1246,13 +1247,13 @@
     container.querySelectorAll('[data-rm-link]').forEach(function (btn) {
       btn.addEventListener('click', function () {
         state.home.footerLinks.splice(parseInt(btn.dataset.rmLink), 1);
-        render(container);
+        render(container); autoSave();
       });
     });
     var addLinkBtn = document.getElementById('addLink');
     if (addLinkBtn) addLinkBtn.addEventListener('click', function () {
       state.home.footerLinks.push({ label: '', url: '' });
-      render(container);
+      render(container); autoSave();
     });
 
     // Export copy

--- a/public/index.html
+++ b/public/index.html
@@ -22,9 +22,9 @@
   <meta name="twitter:title" content="CoreScope">
   <meta name="twitter:description" content="Real-time MeshCore LoRa mesh network analyzer — live packet visualization, node tracking, channel decryption, and route analysis.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Kpa-clawbot/corescope/master/public/og-image.png">
-  <link rel="stylesheet" href="style.css?v=1775062162">
-  <link rel="stylesheet" href="home.css?v=1775062162">
-  <link rel="stylesheet" href="live.css?v=1775062162">
+  <link rel="stylesheet" href="style.css?v=1775076186">
+  <link rel="stylesheet" href="home.css?v=1775076186">
+  <link rel="stylesheet" href="live.css?v=1775076186">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
     crossorigin="anonymous">
@@ -85,30 +85,30 @@
   <main id="app" role="main"></main>
 
   <script src="vendor/qrcode.js"></script>
-  <script src="roles.js?v=1775062162"></script>
-  <script src="customize.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="region-filter.js?v=1775062162"></script>
-  <script src="hop-resolver.js?v=1775062162"></script>
-  <script src="hop-display.js?v=1775062162"></script>
-  <script src="app.js?v=1775062162"></script>
-  <script src="home.js?v=1775062162"></script>
-  <script src="packet-filter.js?v=1775062162"></script>
-  <script src="packets.js?v=1775062162"></script>
-  <script src="geo-filter-overlay.js?v=1775062162"></script>
-  <script src="map.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="channels.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="nodes.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="traces.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="analytics.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-v1-constellation.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-v2-constellation.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="audio-lab.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="live.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="observers.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="observer-detail.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="compare.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="node-analytics.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
-  <script src="perf.js?v=1775062162" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="roles.js?v=1775076186"></script>
+  <script src="customize.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="region-filter.js?v=1775076186"></script>
+  <script src="hop-resolver.js?v=1775076186"></script>
+  <script src="hop-display.js?v=1775076186"></script>
+  <script src="app.js?v=1775076186"></script>
+  <script src="home.js?v=1775076186"></script>
+  <script src="packet-filter.js?v=1775076186"></script>
+  <script src="packets.js?v=1775076186"></script>
+  <script src="geo-filter-overlay.js?v=1775076186"></script>
+  <script src="map.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="channels.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="nodes.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="traces.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="analytics.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-v1-constellation.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-v2-constellation.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="audio-lab.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="live.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="observers.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="observer-detail.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="compare.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="node-analytics.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
+  <script src="perf.js?v=1775076186" onerror="console.error('Failed to load:', this.src)"></script>
 </body>
 </html>

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -1960,6 +1960,43 @@ console.log('\n=== customize.js: initState merge behavior ===');
     assert.strictEqual(state.theme.accent, '#abcdef');
     assert.strictEqual(state.theme.navBg, '#fedcba');
   });
+
+  test('initState uses _SITE_CONFIG_ORIGINAL_HOME to bypass contaminated SITE_CONFIG.home', () => {
+    // Simulates: app.js called mergeUserHomeConfig which mutated SITE_CONFIG.home.steps = []
+    // The original server steps must still be recoverable via _SITE_CONFIG_ORIGINAL_HOME
+    const ctx = makeSandbox();
+    ctx.setTimeout = function (fn) { fn(); return 1; };
+    ctx.clearTimeout = function () {};
+    // SITE_CONFIG.home is contaminated — steps wiped by mergeUserHomeConfig at page load
+    ctx.window.SITE_CONFIG = {
+      home: {
+        heroTitle: 'Server Hero',
+        steps: []   // contaminated — user had steps:[] in localStorage at page load
+      }
+    };
+    // app.js snapshots original before mutation
+    ctx.window._SITE_CONFIG_ORIGINAL_HOME = {
+      heroTitle: 'Server Hero',
+      steps: [{ emoji: '🧪', title: 'Original Step', description: 'from server' }]
+    };
+    const ex = loadCustomizeExports(ctx);
+    ex.initState();
+    const state = ex.getState();
+    assert.strictEqual(state.home.steps.length, 1, 'should restore from snapshot, not contaminated SITE_CONFIG');
+    assert.strictEqual(state.home.steps[0].title, 'Original Step');
+  });
+
+  test('initState uses DEFAULTS.home when no SITE_CONFIG and no snapshot', () => {
+    const ctx = makeSandbox();
+    ctx.setTimeout = function (fn) { fn(); return 1; };
+    ctx.clearTimeout = function () {};
+    // No SITE_CONFIG at all — pure DEFAULTS
+    const ex = loadCustomizeExports(ctx);
+    ex.initState();
+    const state = ex.getState();
+    assert.ok(state.home.steps.length > 0, 'should use DEFAULTS.home.steps when no server config');
+    assert.strictEqual(state.home.steps[0].title, 'Join the Bay Area MeshCore Discord');
+  });
 }
 
 // ===== APP.JS: home rehydration merge =====


### PR DESCRIPTION
## Problem

Fixes #325. Removing all home steps and clicking "Reset my theme" did not restore them.

## Root cause

Two-part bug:

**1. `SITE_CONFIG.home` permanently mutated at page load**
`app.js` calls `mergeUserHomeConfig(SITE_CONFIG, userTheme)` which does `SITE_CONFIG.home = Object.assign({}, serverHome, userTheme.home)`. If the user had `steps: []` saved in localStorage, this sets `SITE_CONFIG.home.steps = []` globally — permanently for the lifetime of the page.

**2. `initState()` reads the contaminated config**
When the customizer opens (or Reset is clicked), `initState()` reads `cfg = window.SITE_CONFIG`. Since `SITE_CONFIG.home.steps` is already `[]`, `state.home.steps` stays `[]` even after `localStorage.removeItem`. `autoSave()` then re-saves `steps: []` straight back.

**Secondary issue:** `data-rm-step` / add / move handlers didn't call `autoSave()`, making step persistence non-deterministic (only saved if a text field edit happened to be pending).

## Fix

- **`app.js`**: snapshot `SITE_CONFIG.home` before `mergeUserHomeConfig` → `window._SITE_CONFIG_ORIGINAL_HOME`
- **`customize.js`**: `initState()` uses `_SITE_CONFIG_ORIGINAL_HOME` instead of the contaminated `cfg.home`
- **`customize.js`**: add `autoSave()` to rm/move/add handlers for steps, checklist, and footer links

## Tests

2 new unit tests covering the snapshot bypass and DEFAULTS fallback. 231 tests pass.

## Checklist
- [x] Branches from `upstream/master`
- [x] No Matomo or local-only commits
- [x] Cache busters bumped
- [x] 231 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)