### PR TITLE
fix: use packet timestamp in bufferPacket instead of arrival time (#475)

### DIFF
--- a/public/live.js
+++ b/public/live.js
@@ -482,7 +482,7 @@
   });
 
   function bufferPacket(pkt) {
-    pkt._ts = Date.now();
+    pkt._ts = new Date(pkt.timestamp || pkt.created_at || Date.now()).getTime();
     const entry = { ts: pkt._ts, pkt };
     VCR.buffer.push(entry);
     // Keep buffer capped at ~2000 — adjust playhead to avoid stale indices (#63)

--- a/public/live.js
+++ b/public/live.js
@@ -481,8 +481,13 @@
     }
   });
 
+  function packetTimestamp(pkt) {
+    return new Date(pkt.timestamp || pkt.created_at || Date.now()).getTime();
+  }
+  if (typeof window !== 'undefined') window._live_packetTimestamp = packetTimestamp;
+
   function bufferPacket(pkt) {
-    pkt._ts = new Date(pkt.timestamp || pkt.created_at || Date.now()).getTime();
+    pkt._ts = packetTimestamp(pkt);
     const entry = { ts: pkt._ts, pkt };
     VCR.buffer.push(entry);
     // Keep buffer capped at ~2000 — adjust playhead to avoid stale indices (#63)

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -2882,6 +2882,26 @@ console.log('\n=== packets.js: savedTimeWindowMin defaults ===');
   });
 }
 
+// ===== live.js: bufferPacket timestamp =====
+console.log('\n=== live.js: bufferPacket timestamp ===');
+{
+  const liveSource = fs.readFileSync('public/live.js', 'utf8');
+
+  test('bufferPacket uses packet timestamp not Date.now()', () => {
+    assert.ok(
+      liveSource.includes('pkt._ts = new Date(pkt.timestamp || pkt.created_at || Date.now()).getTime()'),
+      'bufferPacket must derive _ts from pkt.timestamp, not Date.now()'
+    );
+  });
+
+  test('bufferPacket does not unconditionally assign Date.now() to _ts', () => {
+    assert.ok(
+      !liveSource.match(/pkt\._ts\s*=\s*Date\.now\(\)\s*;/),
+      'bufferPacket must not stamp all packets with receive time'
+    );
+  });
+}
+
 // ===== live.js: nextHop null guards =====
 console.log('\n=== live.js: nextHop null guards ===');
 {

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -2882,23 +2882,76 @@ console.log('\n=== packets.js: savedTimeWindowMin defaults ===');
   });
 }
 
-// ===== live.js: bufferPacket timestamp =====
-console.log('\n=== live.js: bufferPacket timestamp ===');
+// ===== live.js: packetTimestamp =====
+console.log('\n=== live.js: packetTimestamp ===');
 {
-  const liveSource = fs.readFileSync('public/live.js', 'utf8');
+  // packetTimestamp is extracted and exposed via window._live_packetTimestamp
+  const ctx = makeSandbox();
+  ctx.L = {
+    circleMarker: () => { const m = { addTo() { return m; }, bindTooltip() { return m; }, on() { return m; }, setRadius() {}, setStyle() {}, setLatLng() {}, getLatLng() { return { lat: 0, lng: 0 }; }, _baseColor: '', _baseSize: 5, _glowMarker: null }; return m; },
+    polyline: () => { const p = { addTo() { return p; }, setStyle() {}, remove() {} }; return p; },
+    map: () => { const m = { setView() { return m; }, addLayer() { return m; }, on() { return m; }, getZoom() { return 11; }, getCenter() { return { lat: 37, lng: -122 }; }, getBounds() { return { contains: () => true }; }, fitBounds() { return m; }, invalidateSize() {}, remove() {}, hasLayer() { return false; } }; return m; },
+    layerGroup: () => { const g = { addTo() { return g; }, addLayer() {}, removeLayer() {}, clearLayers() {}, hasLayer() { return true; }, eachLayer() {} }; return g; },
+    tileLayer: () => ({ addTo() { return this; } }),
+    control: { attribution: () => ({ addTo() {} }) },
+    DomUtil: { addClass() {}, removeClass() {} },
+  };
+  ctx.getComputedStyle = () => ({ getPropertyValue: () => '' });
+  ctx.matchMedia = () => ({ matches: false, addEventListener: () => {} });
+  ctx.registerPage = () => {};
+  ctx.onWS = () => {};
+  ctx.offWS = () => {};
+  ctx.connectWS = () => {};
+  ctx.api = () => Promise.resolve([]);
+  ctx.invalidateApiCache = () => {};
+  ctx.favStar = () => '';
+  ctx.bindFavStars = () => {};
+  ctx.getFavorites = () => [];
+  ctx.isFavorite = () => false;
+  ctx.HopResolver = { init: () => {}, resolve: () => ({}), ready: () => false };
+  ctx.MeshAudio = null;
+  ctx.RegionFilter = { init: () => {}, getSelected: () => null, onRegionChange: () => {} };
+  ctx.WebSocket = function() { this.close = () => {}; };
+  ctx.navigator = {};
+  ctx.visualViewport = null;
+  ctx.document.documentElement = { getAttribute: () => null, setAttribute: () => {} };
+  ctx.document.body = { appendChild: () => {}, removeChild: () => {}, contains: () => false };
+  ctx.document.querySelector = () => null;
+  ctx.document.querySelectorAll = () => [];
+  ctx.document.createElementNS = () => ctx.document.createElement();
+  ctx.cancelAnimationFrame = () => {};
+  ctx.IATA_COORDS_GEO = {};
+  loadInCtx(ctx, 'public/roles.js');
+  try { loadInCtx(ctx, 'public/live.js'); } catch (e) {
+    for (const k of Object.keys(ctx.window)) ctx[k] = ctx.window[k];
+  }
 
-  test('bufferPacket uses packet timestamp not Date.now()', () => {
-    assert.ok(
-      liveSource.includes('pkt._ts = new Date(pkt.timestamp || pkt.created_at || Date.now()).getTime()'),
-      'bufferPacket must derive _ts from pkt.timestamp, not Date.now()'
-    );
+  const packetTimestamp = ctx._live_packetTimestamp || ctx.window._live_packetTimestamp;
+
+  test('packetTimestamp uses pkt.timestamp ISO string', () => {
+    assert.ok(packetTimestamp, 'packetTimestamp should be exposed');
+    const ts = packetTimestamp({ timestamp: '2026-03-15T12:30:00.000Z' });
+    assert.strictEqual(ts, new Date('2026-03-15T12:30:00.000Z').getTime());
   });
 
-  test('bufferPacket does not unconditionally assign Date.now() to _ts', () => {
-    assert.ok(
-      !liveSource.match(/pkt\._ts\s*=\s*Date\.now\(\)\s*;/),
-      'bufferPacket must not stamp all packets with receive time'
-    );
+  test('packetTimestamp falls back to pkt.created_at', () => {
+    const ts = packetTimestamp({ created_at: '2025-06-01T00:00:00Z' });
+    assert.strictEqual(ts, new Date('2025-06-01T00:00:00Z').getTime());
+  });
+
+  test('packetTimestamp falls back to Date.now() when no fields', () => {
+    const before = Date.now();
+    const ts = packetTimestamp({});
+    const after = Date.now();
+    assert.ok(ts >= before && ts <= after, 'should fall back to current time');
+  });
+
+  test('packetTimestamp prefers timestamp over created_at', () => {
+    const ts = packetTimestamp({
+      timestamp: '2026-01-01T00:00:00Z',
+      created_at: '2025-01-01T00:00:00Z',
+    });
+    assert.strictEqual(ts, new Date('2026-01-01T00:00:00Z').getTime());
   });
 }
 


### PR DESCRIPTION
## Summary
- `bufferPacket()` was overwriting `_ts` with `Date.now()` (receive time) for every live WS packet
- Packets arriving in the same batch all got identical timestamps, making the message history show the same "Xs ago" for every entry (e.g., all show "5s ago")
- Fix: use `pkt.timestamp || pkt.created_at` (mirroring `dbPacketToLive`) so each packet reflects its actual origination time, falling back to `Date.now()` only when the packet has no timestamp

## Root cause
```js
// before
pkt._ts = Date.now();

// after
pkt._ts = new Date(pkt.timestamp || pkt.created_at || Date.now()).getTime();
```

The WS broadcast includes `timestamp` (= `tx.FirstSeen`) in the packet map (store.go:1182), so the field is always present for real packets.

## Test plan
- [x] Open Live page, observe packets arriving — each should show its own relative time, not all the same value
- [x] `node test-frontend-helpers.js` passes (235 tests, 0 failures)

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)