### PR TITLE
fix: stop home config drift in customize buildExport and autoSave (#284)

### DIFF
--- a/public/customize.js
+++ b/public/customize.js
@@ -546,9 +546,10 @@
       try {
         var data = buildExport();
         localStorage.setItem('meshcore-user-theme', JSON.stringify(data));
-        // Sync to SITE_CONFIG so live pages (home, etc.) pick up changes
+        // Sync to SITE_CONFIG so live pages (home, branding) pick up changes
         if (window.SITE_CONFIG) {
           if (state.branding) window.SITE_CONFIG.branding = Object.assign(window.SITE_CONFIG.branding || {}, state.branding);
+          if (state.home) window.SITE_CONFIG.home = Object.assign({}, window._SITE_CONFIG_ORIGINAL_HOME || {}, state.home);
         }
         // Re-render current page to reflect home/branding changes
         window.dispatchEvent(new HashChangeEvent('hashchange'));
@@ -919,13 +920,15 @@
     }
     if (Object.keys(tc).length) out.typeColors = tc;
 
-    // Home
+    // Home — diff against server config (not DEFAULTS) so unmodified server fields
+    // are not captured in localStorage and don't block future server updates.
+    var serverHome = window._SITE_CONFIG_ORIGINAL_HOME || {};
     var hm = {};
-    if (state.home.heroTitle !== DEFAULTS.home.heroTitle) hm.heroTitle = state.home.heroTitle;
-    if (state.home.heroSubtitle !== DEFAULTS.home.heroSubtitle) hm.heroSubtitle = state.home.heroSubtitle;
-    if (JSON.stringify(state.home.steps) !== JSON.stringify(DEFAULTS.home.steps)) hm.steps = state.home.steps;
-    if (JSON.stringify(state.home.checklist) !== JSON.stringify(DEFAULTS.home.checklist)) hm.checklist = state.home.checklist;
-    if (JSON.stringify(state.home.footerLinks) !== JSON.stringify(DEFAULTS.home.footerLinks)) hm.footerLinks = state.home.footerLinks;
+    if (state.home.heroTitle !== (serverHome.heroTitle !== undefined ? serverHome.heroTitle : DEFAULTS.home.heroTitle)) hm.heroTitle = state.home.heroTitle;
+    if (state.home.heroSubtitle !== (serverHome.heroSubtitle !== undefined ? serverHome.heroSubtitle : DEFAULTS.home.heroSubtitle)) hm.heroSubtitle = state.home.heroSubtitle;
+    if (JSON.stringify(state.home.steps) !== JSON.stringify(serverHome.steps !== undefined ? serverHome.steps : DEFAULTS.home.steps)) hm.steps = state.home.steps;
+    if (JSON.stringify(state.home.checklist) !== JSON.stringify(serverHome.checklist !== undefined ? serverHome.checklist : DEFAULTS.home.checklist)) hm.checklist = state.home.checklist;
+    if (JSON.stringify(state.home.footerLinks) !== JSON.stringify(serverHome.footerLinks !== undefined ? serverHome.footerLinks : DEFAULTS.home.footerLinks)) hm.footerLinks = state.home.footerLinks;
     if (Object.keys(hm).length) out.home = hm;
 
     // UI
@@ -1428,6 +1431,10 @@
       }
     }
   } catch {}
+
+  // Test hooks
+  window._customizeBuildExport = buildExport;
+  window._customizeInitState = initState;
 
   // Wire up toggle button (needs DOM)
   document.addEventListener('DOMContentLoaded', () => {

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -2148,6 +2148,67 @@ console.log('\n=== customize.js: initState merge behavior ===');
   });
 }
 
+// ===== customize.js: buildExport home diff against server (#284) =====
+console.log('\n=== customize.js: buildExport home diff vs server ===');
+{
+  function makeCustomizeSandbox(serverHome, localStorageHome) {
+    const ctx = makeSandbox();
+    ctx.window.SITE_CONFIG = { home: Object.assign({}, serverHome), branding: { siteName: 'Test' } };
+    ctx.window._SITE_CONFIG_ORIGINAL_HOME = JSON.parse(JSON.stringify(serverHome));
+    if (localStorageHome) {
+      ctx.localStorage.setItem('meshcore-user-theme', JSON.stringify({ home: localStorageHome }));
+    }
+    loadInCtx(ctx, 'public/roles.js');
+    loadInCtx(ctx, 'public/customize.js');
+    return ctx;
+  }
+
+  test('buildExport does not capture unmodified server steps in export', () => {
+    // Server has custom steps; user only edits checklist
+    const serverHome = {
+      heroTitle: 'Server Hero',
+      steps: [{ title: 'S1', desc: '' }, { title: 'S2', desc: '' }],
+      checklist: [],
+      footerLinks: []
+    };
+    const ctx = makeCustomizeSandbox(serverHome, null);
+    const buildExport = ctx.window._customizeBuildExport;
+    const initState = ctx.window._customizeInitState;
+    if (!buildExport || !initState) { console.log('    SKIP: test hooks not exposed'); return; }
+    initState();
+    const exp = buildExport();
+    assert.ok(!exp.home || !exp.home.steps,
+      'server-provided steps must not appear in export when user did not change them');
+  });
+
+  test('buildExport captures steps only when user actually changed them', () => {
+    const serverHome = {
+      heroTitle: 'Server Hero',
+      steps: [{ title: 'S1', desc: '' }],
+      checklist: [],
+      footerLinks: []
+    };
+    const localHome = { steps: [{ title: 'User Step', desc: 'edited' }] };
+    const ctx = makeCustomizeSandbox(serverHome, localHome);
+    const buildExport = ctx.window._customizeBuildExport;
+    const initState = ctx.window._customizeInitState;
+    if (!buildExport || !initState) { console.log('    SKIP: test hooks not exposed'); return; }
+    initState();
+    const exp = buildExport();
+    assert.ok(exp.home && exp.home.steps,
+      'user-modified steps must appear in export');
+    assert.strictEqual(exp.home.steps[0].title, 'User Step');
+  });
+
+  test('autoSave syncs state.home to SITE_CONFIG.home', () => {
+    const customizeSource = fs.readFileSync('public/customize.js', 'utf8');
+    assert.ok(
+      customizeSource.includes('window.SITE_CONFIG.home = Object.assign({}, window._SITE_CONFIG_ORIGINAL_HOME'),
+      'autoSave must sync state.home to SITE_CONFIG.home using _SITE_CONFIG_ORIGINAL_HOME as base'
+    );
+  });
+}
+
 // ===== APP.JS: home rehydration merge =====
 console.log('\n=== app.js: home rehydration merge ===');
 {


### PR DESCRIPTION
## Summary

Three previous PRs (#287, #317, #460) each patched one code path and broke another. This fixes the two remaining root causes:

**Bug 1 — `buildExport()` baseline wrong**
Home fields were diffed against `DEFAULTS.home` instead of `_SITE_CONFIG_ORIGINAL_HOME` (the server's config). If the server had custom `steps` and the user only edited `checklist`, the server's steps were captured in localStorage. On the next page load those localStorage steps would shadow any future server updates.

**Bug 2 — `autoSave()` did not sync `state.home` to `SITE_CONFIG.home`**
After the user edited home content in the customizer, `autoSave()` wrote to localStorage and dispatched `hashchange`, but `SITE_CONFIG.home` was not updated. The home page re-render read stale data — changes were invisible until a full reload.

## Changes
- `public/customize.js` `buildExport()`: diff each home field against `_SITE_CONFIG_ORIGINAL_HOME || DEFAULTS` so only genuinely user-changed fields are exported
- `public/customize.js` `autoSave()`: sync `state.home` to `SITE_CONFIG.home` using `_SITE_CONFIG_ORIGINAL_HOME` as base (prevents cumulative mutations)
- `public/customize.js`: expose `_customizeBuildExport` and `_customizeInitState` test hooks
- `test-frontend-helpers.js`: 3 new tests verifying the fixes

## Test plan
- [x] Set server home with custom steps. Open customizer, edit checklist only, save. Reload — server steps still visible
- [x] Edit home hero title in customizer — home page updates immediately without reload
- [x] `node test-frontend-helpers.js` passes (257 tests, 0 failures)

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)