### PR TITLE
fix: use _getColCount() in error-state row to match spacers (#406)

### DIFF
--- a/public/packets.js
+++ b/public/packets.js
@@ -620,7 +620,7 @@
     } catch (e) {
       console.error('Failed to load packets:', e);
       const tbody = document.getElementById('pktBody');
-      if (tbody) tbody.innerHTML = '<tr><td colspan="10" class="text-center" style="padding:24px;color:var(--error,#ef4444)"><div role="alert" aria-live="polite">Failed to load packets. Please try again.</div></td></tr>';
+      if (tbody) tbody.innerHTML = '<tr><td colspan="' + _getColCount() + '" class="text-center" style="padding:24px;color:var(--error,#ef4444)"><div role="alert" aria-live="polite">Failed to load packets. Please try again.</div></td></tr>';
     }
   }
 


### PR DESCRIPTION
## Summary

The error-state `<tbody>` row (shown when packet loading fails) hardcoded `colspan="10"`, while the virtual scroll spacers and the empty-state row both use `_getColCount()` (which reads from the actual `<thead>` and falls back to 11). One-line fix: replace the hardcoded value with `_getColCount()`.

Fixes #406

## Test plan

- [x] Trigger the error state (e.g. kill the backend mid-load) — error row should span all columns with no gap on the right
- [x] `node test-packets.js` — 72 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)