### PR TITLE
feat: add distance column to neighbor table in node details

### DIFF
--- a/cmd/server/neighbor_api.go
+++ b/cmd/server/neighbor_api.go
@@ -20,19 +20,20 @@ type NeighborResponse struct {
 }
 
 type NeighborEntry struct {
-	Pubkey     *string           `json:"pubkey"`
-	Prefix     string            `json:"prefix"`
-	Name       *string           `json:"name"`
-	Role       *string           `json:"role"`
-	Count      int               `json:"count"`
-	Score      float64           `json:"score"`
-	FirstSeen  string            `json:"first_seen"`
-	LastSeen   string            `json:"last_seen"`
-	AvgSNR     *float64          `json:"avg_snr"`
-	Observers  []string          `json:"observers"`
-	Ambiguous  bool              `json:"ambiguous"`
-	Unresolved bool              `json:"unresolved,omitempty"`
-	Candidates []CandidateEntry  `json:"candidates,omitempty"`
+	Pubkey      *string          `json:"pubkey"`
+	Prefix      string           `json:"prefix"`
+	Name        *string          `json:"name"`
+	Role        *string          `json:"role"`
+	Count       int              `json:"count"`
+	Score       float64          `json:"score"`
+	FirstSeen   string           `json:"first_seen"`
+	LastSeen    string           `json:"last_seen"`
+	AvgSNR      *float64         `json:"avg_snr"`
+	DistanceKm  *float64         `json:"distance_km,omitempty"`
+	Observers   []string         `json:"observers"`
+	Ambiguous   bool             `json:"ambiguous"`
+	Unresolved  bool             `json:"unresolved,omitempty"`
+	Candidates  []CandidateEntry `json:"candidates,omitempty"`
 }
 
 type CandidateEntry struct {
@@ -115,8 +116,14 @@ func (s *Server) handleNodeNeighbors(w http.ResponseWriter, r *http.Request) {
 	edges := graph.Neighbors(pubkey)
 	now := time.Now()
 
-	// Build node info lookup for names/roles.
+	// Build node info lookup for names/roles/coordinates.
 	nodeMap := s.buildNodeInfoMap()
+
+	// Look up the queried node's GPS coordinates for distance computation.
+	var srcInfo nodeInfo
+	if nodeMap != nil {
+		srcInfo = nodeMap[pubkey]
+	}
 
 	var entries []NeighborEntry
 	totalObs := 0
@@ -170,6 +177,10 @@ func (s *Server) handleNodeNeighbors(w http.ResponseWriter, r *http.Request) {
 			if info, ok := nodeMap[strings.ToLower(neighborPK)]; ok {
 				entry.Name = &info.Name
 				entry.Role = &info.Role
+				if srcInfo.HasGPS && info.HasGPS {
+					d := haversineKm(srcInfo.Lat, srcInfo.Lon, info.Lat, info.Lon)
+					entry.DistanceKm = &d
+				}
 			}
 		}
 

--- a/cmd/server/neighbor_api_test.go
+++ b/cmd/server/neighbor_api_test.go
@@ -347,6 +347,69 @@ func TestNeighborGraphAPI_AmbiguousEdgesCount(t *testing.T) {
 	}
 }
 
+func TestNeighborAPI_DistanceKm_WithGPS(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	db.conn.Exec(`INSERT INTO nodes (public_key, name, role, lat, lon, last_seen, first_seen)
+		VALUES ('aaaa', 'NodeA', 'repeater', 51.5074, -0.1278, '2026-01-01T00:00:00Z', '2025-01-01T00:00:00Z')`)
+	db.conn.Exec(`INSERT INTO nodes (public_key, name, role, lat, lon, last_seen, first_seen)
+		VALUES ('bbbb', 'NodeB', 'repeater', 51.5200, -0.1200, '2026-01-01T00:00:00Z', '2025-01-01T00:00:00Z')`)
+
+	cfg := &Config{Port: 3000}
+	hub := NewHub()
+	srv := NewServer(db, cfg, hub)
+	srv.store = NewPacketStore(db, nil)
+
+	now := time.Now()
+	srv.neighborGraph = makeTestGraph(newEdge("aaaa", "bbbb", "bb", 50, now))
+
+	rr := serveRequest(srv, "GET", "/api/nodes/aaaa/neighbors")
+	var resp NeighborResponse
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+
+	if len(resp.Neighbors) != 1 {
+		t.Fatalf("expected 1 neighbor, got %d", len(resp.Neighbors))
+	}
+	n := resp.Neighbors[0]
+	if n.DistanceKm == nil {
+		t.Fatal("expected distance_km to be set for GPS-enabled nodes")
+	}
+	if *n.DistanceKm <= 0 {
+		t.Errorf("expected positive distance, got %f", *n.DistanceKm)
+	}
+}
+
+func TestNeighborAPI_DistanceKm_NoGPS(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Nodes with 0,0 coords → HasGPS=false
+	db.conn.Exec(`INSERT INTO nodes (public_key, name, role, lat, lon, last_seen, first_seen)
+		VALUES ('aaaa', 'NodeA', 'repeater', 0, 0, '2026-01-01T00:00:00Z', '2025-01-01T00:00:00Z')`)
+	db.conn.Exec(`INSERT INTO nodes (public_key, name, role, lat, lon, last_seen, first_seen)
+		VALUES ('bbbb', 'NodeB', 'repeater', 0, 0, '2026-01-01T00:00:00Z', '2025-01-01T00:00:00Z')`)
+
+	cfg := &Config{Port: 3000}
+	hub := NewHub()
+	srv := NewServer(db, cfg, hub)
+	srv.store = NewPacketStore(db, nil)
+
+	now := time.Now()
+	srv.neighborGraph = makeTestGraph(newEdge("aaaa", "bbbb", "bb", 50, now))
+
+	rr := serveRequest(srv, "GET", "/api/nodes/aaaa/neighbors")
+	var resp NeighborResponse
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+
+	if len(resp.Neighbors) != 1 {
+		t.Fatalf("expected 1 neighbor, got %d", len(resp.Neighbors))
+	}
+	if resp.Neighbors[0].DistanceKm != nil {
+		t.Errorf("expected nil distance_km for nodes without GPS, got %f", *resp.Neighbors[0].DistanceKm)
+	}
+}
+
 func TestNeighborGraphAPI_RegionFilter(t *testing.T) {
 	now := time.Now()
 	// Edge with observer "obs-sjc" — would match region SJC if we had region resolution.

--- a/public/nodes.js
+++ b/public/nodes.js
@@ -204,6 +204,9 @@
         : '<span class="text-muted">—</span>';
       var scoreTitle = 'Observations: ' + nb.count;
       if (nb.avg_snr != null) scoreTitle += ' · Avg SNR: ' + Number(nb.avg_snr).toFixed(1) + ' dB';
+      var distanceCell = nb.distance_km != null
+        ? Number(nb.distance_km).toFixed(1) + ' km'
+        : '<span class="text-muted">—</span>';
       var showOnMap = nb.pubkey
         ? ' <button class="btn-link neighbor-show-map" data-pubkey="' + escapeHtml(nb.pubkey) + '" style="font-size:11px;padding:1px 6px;white-space:nowrap">📍 Map</button>'
         : '';
@@ -213,6 +216,7 @@
         '<td title="' + escapeHtml(scoreTitle) + '">' + Number(nb.score).toFixed(2) + '</td>' +
         '<td>' + nb.count + '</td>' +
         '<td>' + renderNodeTimestampHtml(nb.last_seen) + '</td>' +
+        '<td>' + distanceCell + '</td>' +
         '<td><span title="' + conf.label + '">' + conf.icon + '</span></td>' +
         '<td style="text-align:right">' + showOnMap + '</td>' +
         '</tr>';
@@ -221,7 +225,7 @@
 
   function renderNeighborTable(neighbors, limit) {
     return '<table class="data-table" style="font-size:12px">' +
-      '<thead><tr><th>Neighbor</th><th>Role</th><th>Score</th><th>Obs</th><th>Last Seen</th><th>Conf</th><th></th></tr></thead>' +
+      '<thead><tr><th>Neighbor</th><th>Role</th><th>Score</th><th>Obs</th><th>Last Seen</th><th>Distance</th><th>Conf</th><th></th></tr></thead>' +
       '<tbody>' + renderNeighborRows(neighbors, limit) + '</tbody></table>';
   }
 


### PR DESCRIPTION
Closes #616

## What

Adds a **Distance** column to the neighbor table on the node detail page.

When both the viewed node and a neighbor have GPS coordinates recorded, the table shows the haversine distance between them (e.g. `3.2 km`). When either node lacks GPS, the cell shows `—`.

## Changes

**Backend** (`cmd/server/neighbor_api.go`):
- Added `distance_km *float64` (omitempty) to `NeighborEntry`
- In `handleNodeNeighbors`: look up source node coords from `nodeMap`, then for each resolved (non-ambiguous) neighbor with GPS, compute `haversineKm` and set the field

**Frontend** (`public/nodes.js`):
- Added `Distance` column header between Last Seen and Conf
- Cell renders `X.X km` or `—` (muted) when unavailable

**Tests** (`cmd/server/neighbor_api_test.go`):
- `TestNeighborAPI_DistanceKm_WithGPS`: two nodes with real coords → `distance_km` is positive
- `TestNeighborAPI_DistanceKm_NoGPS`: two nodes at 0,0 → `distance_km` is nil

## Verification

Test at **https://staging.on8ar.eu** — navigate to any node detail page and scroll to the Neighbors section. Nodes with GPS coordinates show a distance; those without show `—`.