### PR TITLE
fix: resolve originLat out-of-scope ReferenceError in resolveHopPositions (#647)

### DIFF
--- a/public/live.js
+++ b/public/live.js
@@ -1942,7 +1942,8 @@
     });
 
     // Add sender position as anchor if available
-    if (payload.pubKey && originLat != null) {
+    const senderLat = payload.lat != null && !(payload.lat === 0 && payload.lon === 0) ? payload.lat : null;
+    if (payload.pubKey && senderLat != null) {
       const existing = raw.find(p => p.key === payload.pubKey);
       if (!existing) {
         raw.unshift({ key: payload.pubKey, pos: [payload.lat, payload.lon], name: payload.name || payload.pubKey.slice(0, 8), known: true });

--- a/public/live.js
+++ b/public/live.js
@@ -1904,6 +1904,12 @@
   }
 
   function resolveHopPositions(hops, payload, resolvedPath) {
+    // Hoist sender GPS guard once — reject (0,0) as "no GPS"
+    const hasValidGps = payload.lat != null && payload.lon != null
+      && !(payload.lat === 0 && payload.lon === 0);
+    const senderLat = hasValidGps ? payload.lat : null;
+    const senderLon = hasValidGps ? payload.lon : null;
+
     // Prefer server-side resolved_path when available
     var resolvedMap;
     if (resolvedPath && resolvedPath.length === hops.length && window.HopResolver && HopResolver.ready()) {
@@ -1911,19 +1917,14 @@
       // Fill in any null entries from client-side fallback, preserving sender GPS context
       var nullHops = hops.filter(function(h, i) { return !resolvedPath[i] && !resolvedMap[h]; });
       if (nullHops.length) {
-        const originLat = payload.lat != null && !(payload.lat === 0 && payload.lon === 0) ? payload.lat : null;
-        const originLon = payload.lon != null && !(payload.lon === 0 && payload.lon === 0) ? payload.lon : null;
-        var fallback = HopResolver.resolve(nullHops, originLat, originLon, null, null, null);
+        var fallback = HopResolver.resolve(nullHops, senderLat, senderLon, null, null, null);
         for (var k in fallback) resolvedMap[k] = fallback[k];
       }
     } else {
       // Delegate to shared HopResolver (from hop-resolver.js) instead of reimplementing
-      const originLat = payload.lat != null && !(payload.lat === 0 && payload.lon === 0) ? payload.lat : null;
-      const originLon = payload.lon != null && !(payload.lon === 0 && payload.lon === 0) ? payload.lon : null;
-
       // Use HopResolver if available and initialized, otherwise fall back to simple lookup
       resolvedMap = (window.HopResolver && HopResolver.ready())
-        ? HopResolver.resolve(hops, originLat, originLon, null, null, null)
+        ? HopResolver.resolve(hops, senderLat, senderLon, null, null, null)
         : {};
     }
 
@@ -1942,7 +1943,6 @@
     });
 
     // Add sender position as anchor if available
-    const senderLat = payload.lat != null && !(payload.lat === 0 && payload.lon === 0) ? payload.lat : null;
     if (payload.pubKey && senderLat != null) {
       const existing = raw.find(p => p.key === payload.pubKey);
       if (!existing) {


### PR DESCRIPTION
## Summary

- `originLat` was declared with `const` inside two block-scoped `if`/`else` branches in `resolveHopPositions` (lines 1914 and 1921) but referenced at line 1945 outside both blocks → `ReferenceError: originLat is not defined` thrown on every packet render on the live page.
- Fix: introduce `senderLat` derived directly from `payload.lat`/`payload.lon` at the point of use, using the same null/zero guard as the existing declarations.

## Test plan

- [x] Live page no longer shows `ReferenceError: originLat is not defined` in the console
- [x] Packet path animations still render correctly for packets with GPS coords
- [x] Packets without GPS coords still handled (senderLat === null, anchor not added)

Closes #647

🤖 Generated with [Claude Code](https://claude.ai/claude-code)