### PR TITLE
feat: serve geofilter builder from app, link from customizer

### DIFF
--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -66,6 +66,12 @@ Click **Import JSON** and paste a previously exported theme. The customizer load
 
 Click **Reset to Defaults** to restore all settings to the built-in defaults.
 
+## GeoFilter Builder
+
+The Export tab includes a **GeoFilter Builder →** link. Click it to open a Leaflet map where you can draw a polygon boundary for your deployment area. The tool generates a `geo_filter` block you can paste directly into `config.json`.
+
+See [Geographic Filtering](geofilter.md) for full details on what geo filtering does and how to configure it.
+
 ## How it works
 
 The customizer writes CSS custom properties (variables) to override the defaults. Exported JSON maps directly to the `theme`, `nodeColors`, `branding`, and `home` sections of [config.json](configuration.md).

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1173,6 +1173,10 @@
       '<details style="margin-top:12px"><summary style="font-size:12px;font-weight:600;cursor:pointer;color:var(--text-muted)">Raw JSON</summary>' +
         '<textarea id="cv2ExportJson" style="width:100%;min-height:200px;font-family:var(--mono);font-size:12px;background:var(--surface-1);border:1px solid var(--border);border-radius:6px;padding:12px;color:var(--text);resize:vertical;box-sizing:border-box;margin-top:8px">' + esc(json) + '</textarea>' +
       '</details>' +
+      '<p class="cust-section-title" style="margin-top:20px">Tools</p>' +
+      '<p style="font-size:12px;color:var(--text-muted);margin-bottom:10px">Server-side configuration helpers.</p>' +
+      '<a href="/geofilter-builder.html" target="_blank" style="display:inline-block;padding:7px 14px;background:var(--surface-1);border:1px solid var(--border);border-radius:6px;color:var(--accent);font-size:13px;text-decoration:none;font-weight:500">🗺️ GeoFilter Builder →</a>' +
+      '<p style="font-size:11px;color:var(--text-muted);margin-top:6px">Draw a polygon on the map to generate a <code style="font-family:var(--mono)">geo_filter</code> block for <code style="font-family:var(--mono)">config.json</code>.</p>' +
     '</div>';
   }
 

--- a/public/geofilter-builder.html
+++ b/public/geofilter-builder.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GeoFilter Builder — CoreScope</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; height: 100vh; display: flex; flex-direction: column; }
+  header { padding: 12px 16px; background: #0f0f23; border-bottom: 1px solid #333; display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+  header h1 { font-size: 1rem; font-weight: 600; color: #4a9eff; white-space: nowrap; }
+  .controls { display: flex; gap: 8px; flex-wrap: wrap; }
+  button { padding: 6px 14px; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; font-weight: 500; }
+  #btnUndo  { background: #333; color: #ccc; }
+  #btnClear { background: #5a2020; color: #ffaaaa; }
+  #btnUndo:hover  { background: #444; }
+  #btnClear:hover { background: #7a2020; }
+  .hint { font-size: 0.8rem; color: #888; margin-left: auto; }
+  #map { flex: 1; }
+  #output-panel { background: #0f0f23; border-top: 1px solid #333; padding: 12px 16px; display: flex; gap: 12px; align-items: flex-start; }
+  #output-panel label { font-size: 0.75rem; color: #888; white-space: nowrap; padding-top: 6px; }
+  #output { flex: 1; background: #111; border: 1px solid #333; border-radius: 6px; padding: 10px 12px; font-family: monospace; font-size: 0.78rem; color: #7ec8e3; white-space: pre; overflow-x: auto; min-height: 54px; max-height: 140px; overflow-y: auto; cursor: text; }
+  #output.empty { color: #555; font-style: italic; }
+  #btnCopy { padding: 6px 14px; background: #1a4a7a; color: #7ec8e3; border-radius: 6px; border: none; cursor: pointer; font-size: 0.85rem; white-space: nowrap; align-self: flex-end; }
+  #btnCopy:hover { background: #2a6aaa; }
+  #btnCopy.copied { background: #1a6a3a; color: #7effa0; }
+  #counter { font-size: 0.8rem; color: #888; padding-top: 6px; white-space: nowrap; }
+  .bufferRow { display: flex; align-items: center; gap: 8px; }
+  .bufferRow label { font-size: 0.85rem; color: #aaa; }
+  .bufferRow input { width: 60px; padding: 5px 8px; background: #222; border: 1px solid #444; border-radius: 6px; color: #eee; font-size: 0.85rem; }
+  #help-bar { background: #0f0f23; padding: 6px 16px; font-size: 0.75rem; color: #666; border-top: 1px solid #222; }
+  #help-bar a { color: #4a9eff; text-decoration: none; }
+  #help-bar a:hover { text-decoration: underline; }
+  #back-link { font-size: 0.8rem; color: #4a9eff; text-decoration: none; white-space: nowrap; }
+  #back-link:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<header>
+  <a href="/" id="back-link">← CoreScope</a>
+  <h1>GeoFilter Builder</h1>
+  <div class="controls">
+    <button id="btnUndo">↩ Undo</button>
+    <button id="btnClear">✕ Clear</button>
+  </div>
+  <div class="bufferRow">
+    <label for="bufferKm">Buffer km:</label>
+    <!-- Extra margin (km) outside the polygon edge that still passes the filter -->
+    <input type="number" id="bufferKm" value="20" min="0" max="500"/>
+  </div>
+  <span class="hint">Click on the map to add polygon points</span>
+</header>
+
+<div id="map"></div>
+
+<!-- Output panel: shows the geo_filter JSON block ready to paste into config.json -->
+<div id="output-panel">
+  <label>config.json</label>
+  <div id="output" class="empty">Add at least 3 points to generate config…</div>
+  <div style="display:flex;flex-direction:column;gap:8px;align-items:flex-end">
+    <span id="counter">0 points</span>
+    <button id="btnCopy">Copy</button>
+  </div>
+</div>
+
+<!-- Instructions: paste the output into config.json as a top-level "geo_filter" key, then restart the server -->
+<div id="help-bar">
+  Copy the JSON above → paste as a top-level key in <code>config.json</code> → restart the server.
+  Nodes with no GPS fix always pass through. Remove the <code>geo_filter</code> block to disable filtering.
+  &nbsp;·&nbsp; <a href="https://github.com/Kpa-clawbot/CoreScope/blob/master/docs/user-guide/geofilter.md" target="_blank">Documentation ↗</a>
+</div>
+
+<script>
+const map = L.map('map').setView([50.5, 4.4], 8);
+
+L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  attribution: '© OpenStreetMap © CartoDB',
+  maxZoom: 19
+}).addTo(map);
+
+let points = [];
+let markers = [];
+let polygon = null;
+let closingLine = null;
+
+function latLonPair(latlng) {
+  return [parseFloat(latlng.lat.toFixed(6)), parseFloat(latlng.lng.toFixed(6))];
+}
+
+function render() {
+  // Remove existing polygon and closing line
+  if (polygon) { map.removeLayer(polygon); polygon = null; }
+  if (closingLine) { map.removeLayer(closingLine); closingLine = null; }
+
+  if (points.length >= 3) {
+    polygon = L.polygon(points, {
+      color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.12
+    }).addTo(map);
+  } else if (points.length === 2) {
+    closingLine = L.polyline(points, { color: '#4a9eff', weight: 2, dashArray: '5,5' }).addTo(map);
+  }
+
+  updateOutput();
+}
+
+function updateOutput() {
+  const el = document.getElementById('output');
+  const counter = document.getElementById('counter');
+  counter.textContent = points.length + ' point' + (points.length !== 1 ? 's' : '');
+
+  if (points.length < 3) {
+    el.textContent = 'Add at least 3 points to generate config…';
+    el.classList.add('empty');
+    return;
+  }
+  el.classList.remove('empty');
+
+  const bufferKm = parseFloat(document.getElementById('bufferKm').value) || 0;
+  // Output format: { "geo_filter": { "bufferKm": N, "polygon": [[lat,lon], ...] } }
+  // Paste this as a top-level key in config.json
+  const config = { bufferKm, polygon: points };
+  el.textContent = JSON.stringify({ geo_filter: config }, null, 2);
+}
+
+map.on('click', function(e) {
+  const pt = latLonPair(e.latlng);
+  points.push(pt);
+
+  const idx = points.length;
+  const marker = L.circleMarker(e.latlng, {
+    radius: 6, color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.9
+  }).addTo(map).bindTooltip(String(idx), { permanent: true, direction: 'top', offset: [0, -8], className: 'pt-label' });
+  markers.push(marker);
+
+  render();
+});
+
+document.getElementById('btnUndo').addEventListener('click', function() {
+  if (!points.length) return;
+  points.pop();
+  const m = markers.pop();
+  if (m) map.removeLayer(m);
+  render();
+});
+
+document.getElementById('btnClear').addEventListener('click', function() {
+  points = [];
+  markers.forEach(m => map.removeLayer(m));
+  markers = [];
+  render();
+});
+
+document.getElementById('bufferKm').addEventListener('input', updateOutput);
+
+document.getElementById('btnCopy').addEventListener('click', function() {
+  if (points.length < 3) return;
+  const text = document.getElementById('output').textContent;
+  navigator.clipboard.writeText(text).then(() => {
+    const btn = document.getElementById('btnCopy');
+    btn.textContent = 'Copied!';
+    btn.classList.add('copied');
+    setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Part of #669 — M2: Link the builder from the app.

- **`public/geofilter-builder.html`** — the existing `tools/geofilter-builder.html` is now served by the static file server at `/geofilter-builder.html`. Additions vs the original: a `← CoreScope` back-link in the header, inline code comments explaining the output format, and a help bar below the output panel with paste instructions and a link to the documentation.
- **`public/customize-v2.js`** — adds a "Tools" section at the bottom of the Export tab with a `🗺️ GeoFilter Builder →` link and a one-line description.
- **`docs/user-guide/customization.md`** — documents the new GeoFilter Builder entry in the Export tab.

> **Note:** `tools/geofilter-builder.html` is kept as-is for local/offline use. The `public/` copy is what the server serves.

> **Depends on:** #734 (M1 docs) for `docs/user-guide/geofilter.md` — the link in the help bar references that file. Can be merged independently; the link still works once M1 lands.

## Test plan

- [x] Open the app, go to Customizer → Export tab — "Tools" section appears with GeoFilter Builder link
- [x] Click the link — opens `/geofilter-builder.html` in a new tab
- [x] Builder loads the Leaflet map, draw 3+ points — JSON output appears
- [x] Copy button works, output is valid `{ "geo_filter": { ... } }` JSON
- [x] `← CoreScope` back-link navigates to `/`
- [x] Help bar shows paste instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)