### PR TITLE
feat: one-click prune nodes outside geofilter (#669 M4)

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -337,4 +338,60 @@ func (c *Config) PropagationBufferMs() int {
 		return c.LiveMap.PropagationBufferMs
 	}
 	return 5000
+}
+
+// SaveGeoFilter writes the geo_filter section back to config.json on disk.
+// Pass gf=nil to remove the filter. The rest of config.json is preserved as-is.
+func SaveGeoFilter(configDir string, gf *GeoFilterConfig) error {
+	var configPath string
+	for _, p := range []string{
+		filepath.Join(configDir, "config.json"),
+		filepath.Join(configDir, "data", "config.json"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			configPath = p
+			break
+		}
+	}
+	if configPath == "" {
+		return fmt.Errorf("config.json not found in %s", configDir)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	// Parse as a raw map so non-struct fields (_comment, etc.) are preserved.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+
+	if gf == nil || len(gf.Polygon) == 0 {
+		delete(raw, "geo_filter")
+	} else {
+		// Round-trip through JSON to get a plain interface{} value.
+		b, _ := json.Marshal(gf)
+		var v interface{}
+		_ = json.Unmarshal(b, &v)
+		raw["geo_filter"] = v
+	}
+
+	out, err := json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	out = append(out, '\n')
+
+	// Atomic write: temp file + rename.
+	tmp := configPath + ".tmp"
+	if err := os.WriteFile(tmp, out, 0644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err := os.Rename(tmp, configPath); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename config: %w", err)
+	}
+	return nil
 }

--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -2232,3 +2232,59 @@ func (db *DB) TouchNodeLastSeen(pubkey string, timestamp string) error {
 	)
 	return err
 }
+
+// NodeForGeoPrune holds the minimal fields needed for geo-filter pruning.
+type NodeForGeoPrune struct {
+	PubKey string
+	Name   string
+	Lat    *float64
+	Lon    *float64
+}
+
+// GetNodesForGeoPrune returns all nodes with their coordinates for geo-filter evaluation.
+func (db *DB) GetNodesForGeoPrune() ([]NodeForGeoPrune, error) {
+	rows, err := db.conn.Query("SELECT public_key, name, lat, lon FROM nodes ORDER BY name")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []NodeForGeoPrune
+	for rows.Next() {
+		var pk string
+		var name sql.NullString
+		var lat, lon sql.NullFloat64
+		if err := rows.Scan(&pk, &name, &lat, &lon); err != nil {
+			continue
+		}
+		n := NodeForGeoPrune{PubKey: pk, Name: name.String}
+		if lat.Valid {
+			v := lat.Float64
+			n.Lat = &v
+		}
+		if lon.Valid {
+			v := lon.Float64
+			n.Lon = &v
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes, rows.Err()
+}
+
+// DeleteNodesByPubkeys deletes nodes by their public keys and returns the count deleted.
+func (db *DB) DeleteNodesByPubkeys(pubkeys []string) (int64, error) {
+	if len(pubkeys) == 0 {
+		return 0, nil
+	}
+	placeholders := strings.Repeat("?,", len(pubkeys))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]interface{}, len(pubkeys))
+	for i, pk := range pubkeys {
+		args[i] = pk
+	}
+	result, err := db.conn.Exec("DELETE FROM nodes WHERE public_key IN ("+placeholders+")", args...)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -227,6 +227,7 @@ func main() {
 
 	// HTTP server
 	srv := NewServer(database, cfg, hub)
+	srv.configDir = configDir
 	srv.store = store
 	router := mux.NewRouter()
 	srv.RegisterRoutes(router)

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -125,6 +125,7 @@ func (s *Server) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/perf", s.handlePerf).Methods("GET")
 	r.Handle("/api/perf/reset", s.requireAPIKey(http.HandlerFunc(s.handlePerfReset))).Methods("POST")
 	r.Handle("/api/admin/prune", s.requireAPIKey(http.HandlerFunc(s.handleAdminPrune))).Methods("POST")
+	r.Handle("/api/admin/prune-geo-filter", s.requireAPIKey(http.HandlerFunc(s.handlePruneGeoFilter))).Methods("POST")
 	r.Handle("/api/debug/affinity", s.requireAPIKey(http.HandlerFunc(s.handleDebugAffinity))).Methods("GET")
 
 	// Packet endpoints
@@ -2400,6 +2401,69 @@ func (s *Server) handleAdminPrune(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Printf("[prune] deleted %d transmissions older than %d days", n, days)
 	writeJSON(w, map[string]interface{}{"deleted": n, "days": days})
+}
+
+// handlePruneGeoFilter identifies (dry_run=true, default) or deletes (confirm=true)
+// nodes whose GPS coordinates fall outside the currently configured geo_filter.
+// Nodes with no GPS fix are always kept. Requires geo_filter to be configured.
+func (s *Server) handlePruneGeoFilter(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.GeoFilter == nil || len(s.cfg.GeoFilter.Polygon) < 3 {
+		writeError(w, http.StatusBadRequest, "no geo_filter configured")
+		return
+	}
+
+	nodes, err := s.db.GetNodesForGeoPrune()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "db error")
+		return
+	}
+
+	type nodeResult struct {
+		PubKey string   `json:"pubkey"`
+		Name   string   `json:"name"`
+		Lat    *float64 `json:"lat"`
+		Lon    *float64 `json:"lon"`
+	}
+
+	var outside []nodeResult
+	for _, n := range nodes {
+		var lat, lon float64
+		if n.Lat != nil {
+			lat = *n.Lat
+		}
+		if n.Lon != nil {
+			lon = *n.Lon
+		}
+		if !NodePassesGeoFilter(lat, lon, s.cfg.GeoFilter) {
+			outside = append(outside, nodeResult{PubKey: n.PubKey, Name: n.Name, Lat: n.Lat, Lon: n.Lon})
+		}
+	}
+
+	if r.URL.Query().Get("confirm") != "true" {
+		// Dry run — return preview without deleting
+		writeJSON(w, map[string]interface{}{
+			"dryRun": true,
+			"count":  len(outside),
+			"nodes":  outside,
+		})
+		return
+	}
+
+	// Confirmed — delete the nodes
+	pubkeys := make([]string, len(outside))
+	for i, n := range outside {
+		pubkeys[i] = n.PubKey
+	}
+	deleted, err := s.db.DeleteNodesByPubkeys(pubkeys)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "delete failed")
+		return
+	}
+	log.Printf("[geo-prune] deleted %d nodes outside geo filter", deleted)
+	writeJSON(w, map[string]interface{}{
+		"dryRun":  false,
+		"deleted": deleted,
+	})
 }
 
 // constantTimeEqual compares two strings in constant time to prevent timing attacks.

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -24,6 +24,7 @@ type Server struct {
 	cfg       *Config
 	hub       *Hub
 	store     *PacketStore // in-memory packet store (nil = fallback to DB)
+	configDir string       // directory containing config.json (for write-back)
 	startedAt time.Time
 	perfStats *PerfStats
 	version   string
@@ -116,6 +117,7 @@ func (s *Server) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/config/theme", s.handleConfigTheme).Methods("GET")
 	r.HandleFunc("/api/config/map", s.handleConfigMap).Methods("GET")
 	r.HandleFunc("/api/config/geo-filter", s.handleConfigGeoFilter).Methods("GET")
+	r.Handle("/api/config/geo-filter", s.requireAPIKey(http.HandlerFunc(s.handlePutConfigGeoFilter))).Methods("PUT")
 
 	// System endpoints
 	r.HandleFunc("/api/health", s.handleHealth).Methods("GET")
@@ -425,11 +427,50 @@ func (s *Server) handleConfigMap(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleConfigGeoFilter(w http.ResponseWriter, r *http.Request) {
 	gf := s.cfg.GeoFilter
+	writeEnabled := s.cfg != nil && s.cfg.APIKey != "" && !IsWeakAPIKey(s.cfg.APIKey)
 	if gf == nil || len(gf.Polygon) == 0 {
-		writeJSON(w, map[string]interface{}{"polygon": nil, "bufferKm": 0})
+		writeJSON(w, map[string]interface{}{"polygon": nil, "bufferKm": 0, "writeEnabled": writeEnabled})
 		return
 	}
-	writeJSON(w, map[string]interface{}{"polygon": gf.Polygon, "bufferKm": gf.BufferKm})
+	writeJSON(w, map[string]interface{}{"polygon": gf.Polygon, "bufferKm": gf.BufferKm, "writeEnabled": writeEnabled})
+}
+
+func (s *Server) handlePutConfigGeoFilter(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Polygon  [][2]float64 `json:"polygon"`
+		BufferKm float64      `json:"bufferKm"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	// Allow clearing (empty/null polygon) or a valid polygon with ≥ 3 points.
+	if len(body.Polygon) > 0 && len(body.Polygon) < 3 {
+		writeError(w, http.StatusBadRequest, "polygon must have at least 3 points")
+		return
+	}
+
+	var gf *GeoFilterConfig
+	if len(body.Polygon) >= 3 {
+		gf = &GeoFilterConfig{Polygon: body.Polygon, BufferKm: body.BufferKm}
+	}
+
+	if s.configDir != "" {
+		if err := SaveGeoFilter(s.configDir, gf); err != nil {
+			log.Printf("[geofilter] save failed: %v", err)
+			writeError(w, http.StatusInternalServerError, "failed to save config")
+			return
+		}
+	}
+
+	s.cfg.GeoFilter = gf
+
+	if gf != nil {
+		writeJSON(w, map[string]interface{}{"polygon": gf.Polygon, "bufferKm": gf.BufferKm})
+	} else {
+		writeJSON(w, map[string]interface{}{"polygon": nil, "bufferKm": 0})
+	}
 }
 
 // --- System Handlers ---

--- a/cmd/server/routes_test.go
+++ b/cmd/server/routes_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -2839,6 +2841,34 @@ func TestConfigGeoFilterEndpoint(t *testing.T) {
 		if body["bufferKm"] == nil {
 			t.Error("expected bufferKm in response")
 		}
+		if _, ok := body["writeEnabled"]; !ok {
+			t.Error("expected writeEnabled field in response")
+		}
+		// No apiKey configured → writeEnabled should be false
+		if body["writeEnabled"] != false {
+			t.Errorf("expected writeEnabled=false when no apiKey, got %v", body["writeEnabled"])
+		}
+	})
+
+	t.Run("writeEnabled true when strong apiKey configured", func(t *testing.T) {
+		db := setupTestDB(t)
+		cfg := &Config{Port: 3000, APIKey: "a-strong-api-key-1234"}
+		hub := NewHub()
+		srv := NewServer(db, cfg, hub)
+		srv.store = NewPacketStore(db, nil)
+		srv.store.Load()
+		router := mux.NewRouter()
+		srv.RegisterRoutes(router)
+
+		req := httptest.NewRequest("GET", "/api/config/geo-filter", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		var body map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &body)
+		if body["writeEnabled"] != true {
+			t.Errorf("expected writeEnabled=true when strong apiKey configured, got %v", body["writeEnabled"])
+		}
 	})
 }
 
@@ -3807,4 +3837,163 @@ func TestMetricsAPIEndpoints(t *testing.T) {
 	if !ok || len(observers) != 1 {
 		t.Errorf("expected 1 observer in summary, got %v", resp2["observers"])
 	}
+}
+
+// --- geo-filter write-back tests ---
+
+func setupGeoFilterServer(t *testing.T, apiKey string) (*Server, *mux.Router, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgJSON := `{"port":3000,"apiKey":"` + apiKey + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	db := setupTestDB(t)
+	seedTestData(t, db)
+	cfg := &Config{Port: 3000, APIKey: apiKey}
+	hub := NewHub()
+	srv := NewServer(db, cfg, hub)
+	srv.configDir = dir
+	store := NewPacketStore(db, nil)
+	if err := store.Load(); err != nil {
+		t.Fatalf("store.Load: %v", err)
+	}
+	srv.store = store
+	router := mux.NewRouter()
+	srv.RegisterRoutes(router)
+	return srv, router, dir
+}
+
+func TestPutConfigGeoFilter(t *testing.T) {
+	const apiKey = "a-strong-api-key-for-testing"
+
+	t.Run("saves valid polygon and updates in-memory config", func(t *testing.T) {
+		srv, router, dir := setupGeoFilterServer(t, apiKey)
+
+		body := `{"polygon":[[51.0,4.0],[51.0,5.0],[50.5,5.0],[50.5,4.0]],"bufferKm":15}`
+		req := httptest.NewRequest("PUT", "/api/config/geo-filter", strings.NewReader(body))
+		req.Header.Set("X-API-Key", apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		// In-memory config updated
+		if srv.cfg.GeoFilter == nil {
+			t.Fatal("expected in-memory GeoFilter to be set")
+		}
+		if len(srv.cfg.GeoFilter.Polygon) != 4 {
+			t.Errorf("expected 4 polygon points, got %d", len(srv.cfg.GeoFilter.Polygon))
+		}
+		if srv.cfg.GeoFilter.BufferKm != 15 {
+			t.Errorf("expected bufferKm=15, got %v", srv.cfg.GeoFilter.BufferKm)
+		}
+
+		// config.json updated on disk
+		data, _ := os.ReadFile(filepath.Join(dir, "config.json"))
+		if !bytes.Contains(data, []byte("geo_filter")) {
+			t.Error("expected geo_filter key in saved config.json")
+		}
+	})
+
+	t.Run("clears filter when polygon is empty", func(t *testing.T) {
+		srv, router, dir := setupGeoFilterServer(t, apiKey)
+		// Pre-set a filter so we can clear it
+		srv.cfg.GeoFilter = &GeoFilterConfig{Polygon: [][2]float64{{51.0, 4.0}, {51.0, 5.0}, {50.5, 4.0}}, BufferKm: 10}
+
+		req := httptest.NewRequest("PUT", "/api/config/geo-filter", strings.NewReader(`{"polygon":null}`))
+		req.Header.Set("X-API-Key", apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		if srv.cfg.GeoFilter != nil {
+			t.Error("expected in-memory GeoFilter to be cleared")
+		}
+		data, _ := os.ReadFile(filepath.Join(dir, "config.json"))
+		if bytes.Contains(data, []byte("geo_filter")) {
+			t.Error("expected geo_filter to be removed from config.json")
+		}
+	})
+
+	t.Run("rejects polygon with fewer than 3 points", func(t *testing.T) {
+		_, router, _ := setupGeoFilterServer(t, apiKey)
+
+		body := `{"polygon":[[51.0,4.0],[51.0,5.0]],"bufferKm":0}`
+		req := httptest.NewRequest("PUT", "/api/config/geo-filter", strings.NewReader(body))
+		req.Header.Set("X-API-Key", apiKey)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("rejects missing API key", func(t *testing.T) {
+		_, router, _ := setupGeoFilterServer(t, apiKey)
+
+		body := `{"polygon":[[51.0,4.0],[51.0,5.0],[50.5,4.0]],"bufferKm":0}`
+		req := httptest.NewRequest("PUT", "/api/config/geo-filter", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestSaveGeoFilter(t *testing.T) {
+	t.Run("saves and reads back", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(`{"port":3000}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		gf := &GeoFilterConfig{
+			Polygon:  [][2]float64{{51.0, 4.0}, {51.0, 5.0}, {50.5, 4.0}},
+			BufferKm: 20,
+		}
+		if err := SaveGeoFilter(dir, gf); err != nil {
+			t.Fatalf("SaveGeoFilter: %v", err)
+		}
+		data, _ := os.ReadFile(filepath.Join(dir, "config.json"))
+		if !bytes.Contains(data, []byte("geo_filter")) {
+			t.Error("expected geo_filter in saved config")
+		}
+		if !bytes.Contains(data, []byte(`"bufferKm"`)) {
+			t.Error("expected bufferKm in saved config")
+		}
+	})
+
+	t.Run("removes geo_filter key when gf is nil", func(t *testing.T) {
+		dir := t.TempDir()
+		initial := `{"port":3000,"geo_filter":{"polygon":[[1,2],[3,4],[5,6]],"bufferKm":5}}`
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(initial), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := SaveGeoFilter(dir, nil); err != nil {
+			t.Fatalf("SaveGeoFilter: %v", err)
+		}
+		data, _ := os.ReadFile(filepath.Join(dir, "config.json"))
+		if bytes.Contains(data, []byte("geo_filter")) {
+			t.Error("expected geo_filter to be removed")
+		}
+	})
+
+	t.Run("returns error when config.json not found", func(t *testing.T) {
+		dir := t.TempDir()
+		err := SaveGeoFilter(dir, nil)
+		if err == nil {
+			t.Error("expected error when config.json not found")
+		}
+	})
 }

--- a/cmd/server/routes_test.go
+++ b/cmd/server/routes_test.go
@@ -3997,3 +3997,175 @@ func TestSaveGeoFilter(t *testing.T) {
 		}
 	})
 }
+
+// --- prune-geo-filter endpoint tests ---
+
+func setupPruneGeoFilterServer(t *testing.T, apiKey string, gf *GeoFilterConfig) (*Server, *mux.Router) {
+	t.Helper()
+	db := setupTestDB(t)
+	seedTestData(t, db)
+	// Add a node clearly outside the geo filter (high lat/lon in Europe)
+	db.conn.Exec(`INSERT INTO nodes (public_key, name, role, lat, lon, last_seen, first_seen, advert_count)
+		VALUES ('aaaa111122223333', 'OutsideNode', 'repeater', 51.5, 4.5, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1)`)
+	// Add a node with no GPS (should always be kept)
+	db.conn.Exec(`INSERT INTO nodes (public_key, name, role, last_seen, first_seen, advert_count)
+		VALUES ('bbbb111122223333', 'NoGPSNode', 'companion', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 1)`)
+
+	cfg := &Config{Port: 3000, APIKey: apiKey, GeoFilter: gf}
+	hub := NewHub()
+	srv := NewServer(db, cfg, hub)
+	store := NewPacketStore(db, nil)
+	store.Load()
+	srv.store = store
+	router := mux.NewRouter()
+	srv.RegisterRoutes(router)
+	return srv, router
+}
+
+func TestPruneGeoFilterEndpoint(t *testing.T) {
+	const apiKey = "a-strong-api-key-for-testing"
+
+	// Polygon around San Jose — seed nodes are at 37.4–37.6, -122.1 to -121.9 (inside)
+	// OutsideNode is at 51.5, 4.5 (Europe — outside)
+	gf := &GeoFilterConfig{
+		Polygon:  [][2]float64{{37.0, -123.0}, {38.0, -123.0}, {38.0, -121.0}, {37.0, -121.0}},
+		BufferKm: 0,
+	}
+
+	t.Run("dry run returns outside nodes without deleting", func(t *testing.T) {
+		_, router := setupPruneGeoFilterServer(t, apiKey, gf)
+
+		req := httptest.NewRequest("POST", "/api/admin/prune-geo-filter", nil)
+		req.Header.Set("X-API-Key", apiKey)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var body map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &body)
+		if body["dryRun"] != true {
+			t.Error("expected dryRun=true")
+		}
+		count, _ := body["count"].(float64)
+		if count != 1 {
+			t.Errorf("expected 1 outside node (OutsideNode), got %v", count)
+		}
+		nodes, _ := body["nodes"].([]interface{})
+		if len(nodes) != 1 {
+			t.Fatalf("expected 1 node in preview, got %d", len(nodes))
+		}
+		n, _ := nodes[0].(map[string]interface{})
+		if n["name"] != "OutsideNode" {
+			t.Errorf("expected OutsideNode, got %v", n["name"])
+		}
+	})
+
+	t.Run("confirm=true deletes outside nodes", func(t *testing.T) {
+		srv, router := setupPruneGeoFilterServer(t, apiKey, gf)
+
+		req := httptest.NewRequest("POST", "/api/admin/prune-geo-filter?confirm=true", nil)
+		req.Header.Set("X-API-Key", apiKey)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var body map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &body)
+		if body["dryRun"] != false {
+			t.Error("expected dryRun=false")
+		}
+		deleted, _ := body["deleted"].(float64)
+		if deleted != 1 {
+			t.Errorf("expected 1 deleted, got %v", deleted)
+		}
+
+		// Verify node is actually gone from DB
+		var count int
+		srv.db.conn.QueryRow("SELECT COUNT(*) FROM nodes WHERE public_key = 'aaaa111122223333'").Scan(&count)
+		if count != 0 {
+			t.Error("expected OutsideNode to be deleted from DB")
+		}
+		// No-GPS node must still exist
+		srv.db.conn.QueryRow("SELECT COUNT(*) FROM nodes WHERE public_key = 'bbbb111122223333'").Scan(&count)
+		if count != 1 {
+			t.Error("expected NoGPSNode to be kept")
+		}
+	})
+
+	t.Run("returns 400 when no geo filter configured", func(t *testing.T) {
+		_, router := setupPruneGeoFilterServer(t, apiKey, nil)
+
+		req := httptest.NewRequest("POST", "/api/admin/prune-geo-filter", nil)
+		req.Header.Set("X-API-Key", apiKey)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("returns 401 without API key", func(t *testing.T) {
+		_, router := setupPruneGeoFilterServer(t, apiKey, gf)
+
+		req := httptest.NewRequest("POST", "/api/admin/prune-geo-filter", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", w.Code)
+		}
+	})
+}
+
+func TestGetNodesForGeoPrune(t *testing.T) {
+	db := setupTestDB(t)
+	seedTestData(t, db)
+
+	nodes, err := db.GetNodesForGeoPrune()
+	if err != nil {
+		t.Fatalf("GetNodesForGeoPrune: %v", err)
+	}
+	if len(nodes) == 0 {
+		t.Error("expected nodes to be returned")
+	}
+	// Check that nodes with lat/lon have non-nil fields
+	for _, n := range nodes {
+		if n.PubKey == "" {
+			t.Error("expected non-empty pubkey")
+		}
+	}
+}
+
+func TestDeleteNodesByPubkeys(t *testing.T) {
+	db := setupTestDB(t)
+	seedTestData(t, db)
+
+	// Count before
+	var before int
+	db.conn.QueryRow("SELECT COUNT(*) FROM nodes").Scan(&before)
+	if before == 0 {
+		t.Skip("no nodes to delete")
+	}
+
+	// Delete one node
+	var pk string
+	db.conn.QueryRow("SELECT public_key FROM nodes LIMIT 1").Scan(&pk)
+	n, err := db.DeleteNodesByPubkeys([]string{pk})
+	if err != nil {
+		t.Fatalf("DeleteNodesByPubkeys: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 deleted, got %d", n)
+	}
+
+	var after int
+	db.conn.QueryRow("SELECT COUNT(*) FROM nodes").Scan(&after)
+	if after != before-1 {
+		t.Errorf("expected %d nodes after delete, got %d", before-1, after)
+	}
+}

--- a/config.example.json
+++ b/config.example.json
@@ -153,6 +153,16 @@
     ],
     "zoom": 9
   },
+  "geo_filter": {
+    "polygon": [
+      [37.80, -122.52],
+      [37.80, -121.80],
+      [37.20, -121.80],
+      [37.20, -122.52]
+    ],
+    "bufferKm": 20,
+    "_comment": "Optional. Restricts ingestion and API responses to nodes within the polygon + bufferKm. Polygon is an array of [lat, lon] pairs (minimum 3). Use tools/geofilter-builder.html to draw a polygon visually. Remove this section to disable filtering. Nodes with no GPS fix are always allowed through."
+  },
   "regions": {
     "SJC": "San Jose, US",
     "SFO": "San Francisco, US",

--- a/config.example.json
+++ b/config.example.json
@@ -153,6 +153,16 @@
     ],
     "zoom": 9
   },
+  "geo_filter": {
+    "polygon": [
+      [37.80, -122.52],
+      [37.80, -121.80],
+      [37.20, -121.80],
+      [37.20, -122.52]
+    ],
+    "bufferKm": 20,
+    "_comment": "Optional. Restricts ingestion and API responses to nodes within the polygon + bufferKm. Polygon is an array of [lat, lon] pairs (minimum 3). Use the GeoFilter tab in the Customizer (requires apiKey) or tools/geofilter-builder.html to draw a polygon visually. Remove this section to disable filtering. Nodes with no GPS fix are always allowed through."
+  },
   "regions": {
     "SJC": "San Jose, US",
     "SFO": "San Francisco, US",

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -176,6 +176,21 @@ Lower values = fresher data but more server load.
 
 Provide cert and key paths to enable HTTPS.
 
+## Geographic filtering
+
+```json
+"geo_filter": {
+  "polygon": [[51.55, 3.80], [51.55, 5.90], [50.65, 5.90], [50.65, 3.80]],
+  "bufferKm": 20
+}
+```
+
+Restricts ingestion and API responses to nodes within the polygon plus a buffer margin. Remove the block to disable filtering. Nodes with no GPS fix always pass through.
+
+Can also be configured live via the **🗺️ GeoFilter** tab in the Customizer (requires `apiKey`).
+
+See [Geographic Filtering](geofilter.md) for the full guide.
+
 ## Home page
 
 The `home` section customizes the onboarding experience. See `config.example.json` for the full structure including `steps`, `checklist`, and `footerLinks`.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -176,6 +176,19 @@ Lower values = fresher data but more server load.
 
 Provide cert and key paths to enable HTTPS.
 
+## Geographic filtering
+
+```json
+"geo_filter": {
+  "polygon": [[51.55, 3.80], [51.55, 5.90], [50.65, 5.90], [50.65, 3.80]],
+  "bufferKm": 20
+}
+```
+
+Restricts ingestion and API responses to nodes within the polygon plus a buffer margin. Remove the block to disable filtering. Nodes with no GPS fix always pass through.
+
+See [Geographic Filtering](geofilter.md) for the full guide including the visual polygon builder and the prune script for cleaning up historical data.
+
 ## Home page
 
 The `home` section customizes the onboarding experience. See `config.example.json` for the full structure including `steps`, `checklist`, and `footerLinks`.

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -66,6 +66,14 @@ Click **Import JSON** and paste a previously exported theme. The customizer load
 
 Click **Reset to Defaults** to restore all settings to the built-in defaults.
 
+## GeoFilter (admin only)
+
+The **🗺️ GeoFilter** tab lets operators configure geographic filtering directly from the customizer. It shows the active polygon on a Leaflet map and — on servers with a write-capable `apiKey` — allows editing the polygon and saving back to `config.json` without a restart.
+
+The editing controls are only revealed after the server confirms write access. On public deployments without an `apiKey`, the tab is read-only.
+
+See [Geographic Filtering](geofilter.md) for the full guide, including the API, the prune script, and the standalone GeoFilter Builder.
+
 ## How it works
 
 The customizer writes CSS custom properties (variables) to override the defaults. Exported JSON maps directly to the `theme`, `nodeColors`, `branding`, and `home` sections of [config.json](configuration.md).

--- a/docs/user-guide/customization.md
+++ b/docs/user-guide/customization.md
@@ -66,6 +66,12 @@ Click **Import JSON** and paste a previously exported theme. The customizer load
 
 Click **Reset to Defaults** to restore all settings to the built-in defaults.
 
+## GeoFilter Builder
+
+The Export tab includes a **GeoFilter Builder →** link. Click it to open a Leaflet map where you can draw a polygon boundary for your deployment area. The tool generates a `geo_filter` block you can paste directly into `config.json`.
+
+See [Geographic Filtering](geofilter.md) for full details on what geo filtering does and how to configure it.
+
 ## How it works
 
 The customizer writes CSS custom properties (variables) to override the defaults. Exported JSON maps directly to the `theme`, `nodeColors`, `branding`, and `home` sections of [config.json](configuration.md).

--- a/docs/user-guide/geofilter.md
+++ b/docs/user-guide/geofilter.md
@@ -101,9 +101,33 @@ Request body:
 
 To clear the filter, send `{"polygon": null}`.
 
+```
+POST /api/admin/prune-geo-filter
+POST /api/admin/prune-geo-filter?confirm=true
+```
+
+Requires `X-API-Key` header. Without `?confirm=true`, performs a dry run and returns the list of nodes that would be deleted. With `?confirm=true`, permanently deletes them from the database.
+
+Response (dry run or confirmed):
+```json
+{"deleted": 5, "nodes": [{"pubKey": "...", "name": "NodeName", "lat": 51.12, "lon": 4.50}]}
+```
+
 ## Cleaning up historical nodes
 
-The ingestor prevents new out-of-bounds nodes from being ingested, but it does not retroactively remove nodes stored before the filter was configured. For that, use the prune script:
+The ingestor prevents new out-of-bounds nodes from being ingested, but it does not retroactively remove nodes stored before the filter was configured.
+
+### One-click prune from the Customizer (recommended)
+
+If `writeEnabled` is true (server has a write-capable `apiKey`), the GeoFilter tab shows a **Prune nodes** section at the bottom:
+
+1. Click **Preview** — the server dry-runs the deletion and lists every node that falls outside the current polygon + buffer. No data is deleted yet.
+2. Review the list. It shows the node name (or public key) and coordinates.
+3. Click **Confirm delete** to permanently remove those nodes from the database.
+
+Nodes without GPS coordinates are always kept.
+
+### CLI alternative (Python script)
 
 **File:** `scripts/prune-nodes-outside-geo-filter.py`
 
@@ -125,4 +149,4 @@ docker exec -it meshcore-analyzer \
 
 The script reads `geo_filter.polygon` and `geo_filter.bufferKm` from config, lists nodes that fall outside, then asks for `yes` confirmation before deleting. Nodes without coordinates are always kept.
 
-This is a **one-time migration tool** — run it once after first configuring `geo_filter` to clean up pre-filter data. The ingestor handles all subsequent filtering automatically.
+Both the UI button and the script are **one-time migration tools** — run once after first configuring `geo_filter` to clean up pre-filter data. The ingestor handles all subsequent filtering automatically.

--- a/docs/user-guide/geofilter.md
+++ b/docs/user-guide/geofilter.md
@@ -1,0 +1,114 @@
+# Geographic Filtering
+
+CoreScope supports geographic filtering to restrict which nodes are ingested and returned in API responses. This is useful for public-facing deployments that should only show activity in a specific region.
+
+## How it works
+
+Geographic filtering operates at two levels:
+
+- **Ingest time** — ADVERT packets carrying GPS coordinates are rejected by the ingestor if the node falls outside the configured area. The node never reaches the database.
+- **API responses** — Nodes already in the database are filtered from the `/api/nodes` response if they fall outside the area. This covers nodes ingested before the filter was configured.
+
+Nodes with no GPS fix (`lat=0, lon=0` or missing coordinates) always pass the filter regardless of configuration.
+
+## Configuration
+
+Add a `geo_filter` block to `config.json`:
+
+```json
+"geo_filter": {
+  "polygon": [
+    [51.55, 3.80],
+    [51.55, 5.90],
+    [50.65, 5.90],
+    [50.65, 3.80]
+  ],
+  "bufferKm": 20
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `polygon` | `[[lat, lon], ...]` | Array of at least 3 coordinate pairs defining the boundary |
+| `bufferKm` | number | Extra distance (km) around the polygon edge that is also accepted. `0` = exact boundary |
+
+Both the server and the ingestor read `geo_filter` from `config.json`. Restart both after changing this section.
+
+To disable filtering entirely, remove the `geo_filter` block.
+
+### Legacy bounding box
+
+An older bounding box format is also supported as a fallback when no `polygon` is present:
+
+```json
+"geo_filter": {
+  "latMin": 50.65,
+  "latMax": 51.55,
+  "lonMin": 3.80,
+  "lonMax": 5.90
+}
+```
+
+Prefer the polygon format — it supports irregular shapes and the `bufferKm` margin.
+
+## API endpoint
+
+The current geo filter configuration is exposed at:
+
+```
+GET /api/config/geo-filter
+```
+
+The frontend reads this endpoint to display the active filter. No authentication is required (the endpoint returns config, not private data).
+
+## GeoFilter Builder
+
+The simplest way to create a polygon is the included visual builder:
+
+**File:** `tools/geofilter-builder.html`
+
+Open it directly in a browser — it runs entirely client-side, no server required:
+
+```bash
+# From the project root
+open tools/geofilter-builder.html          # macOS
+xdg-open tools/geofilter-builder.html     # Linux
+start tools/geofilter-builder.html        # Windows
+```
+
+**Workflow:**
+
+1. The map opens centered on Belgium by default. Navigate to your region.
+2. Click on the map to add polygon vertices. Each click adds a numbered point.
+3. Add at least 3 points to form a closed polygon.
+4. Adjust **Buffer km** (default 20) to add a margin around the polygon edge.
+5. The generated JSON block appears at the bottom of the page — copy it directly into `config.json`.
+6. Use **↩ Undo** to remove the last point, **✕ Clear** to start over.
+
+The output is a complete `{ "geo_filter": { ... } }` block ready to paste into `config.json`.
+
+## Cleaning up historical nodes
+
+The ingestor prevents new out-of-bounds nodes from being ingested, but it does not retroactively remove nodes that were stored before the filter was configured. For that, use the prune script.
+
+**File:** `scripts/prune-nodes-outside-geo-filter.py`
+
+```bash
+# Dry run — shows what would be deleted without making any changes
+python3 scripts/prune-nodes-outside-geo-filter.py --dry-run
+
+# Default paths: /app/data/meshcore.db and /app/config.json
+python3 scripts/prune-nodes-outside-geo-filter.py
+
+# Custom paths
+python3 scripts/prune-nodes-outside-geo-filter.py /path/to/meshcore.db \
+  --config /path/to/config.json
+
+# In Docker — run inside the container
+docker exec -it meshcore-analyzer \
+  python3 /app/scripts/prune-nodes-outside-geo-filter.py --dry-run
+```
+
+The script reads `geo_filter.polygon` and `geo_filter.bufferKm` from config, lists the nodes that fall outside, then asks for `yes` confirmation before deleting. Nodes without coordinates are always kept.
+
+This is a **one-time migration tool** — run it once after first configuring `geo_filter` to clean up pre-filter data. The ingestor handles all subsequent filtering automatically at ingest time.

--- a/docs/user-guide/geofilter.md
+++ b/docs/user-guide/geofilter.md
@@ -1,0 +1,128 @@
+# Geographic Filtering
+
+CoreScope supports geographic filtering to restrict which nodes are ingested and returned in API responses. This is useful for public-facing deployments that should only show activity in a specific region.
+
+## How it works
+
+Geographic filtering operates at two levels:
+
+- **Ingest time** — ADVERT packets carrying GPS coordinates are rejected by the ingestor if the node falls outside the configured area. The node never reaches the database.
+- **API responses** — Nodes already in the database are filtered from the `/api/nodes` response if they fall outside the area. This covers nodes ingested before the filter was configured.
+
+Nodes with no GPS fix (`lat=0, lon=0` or missing coordinates) always pass the filter regardless of configuration.
+
+## Configuration
+
+Add a `geo_filter` block to `config.json`:
+
+```json
+"geo_filter": {
+  "polygon": [
+    [51.55, 3.80],
+    [51.55, 5.90],
+    [50.65, 5.90],
+    [50.65, 3.80]
+  ],
+  "bufferKm": 20
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `polygon` | `[[lat, lon], ...]` | Array of at least 3 coordinate pairs defining the boundary |
+| `bufferKm` | number | Extra distance (km) outside the polygon edge that is also accepted. `0` = exact boundary |
+
+Both the server and the ingestor read `geo_filter` from `config.json`. Restart both after changing this section manually.
+
+To disable filtering entirely, remove the `geo_filter` block.
+
+### Legacy bounding box
+
+An older bounding box format is also supported as a fallback when no `polygon` is present:
+
+```json
+"geo_filter": {
+  "latMin": 50.65,
+  "latMax": 51.55,
+  "lonMin": 3.80,
+  "lonMax": 5.90
+}
+```
+
+Prefer the polygon format — it supports irregular shapes and the `bufferKm` margin.
+
+## Configuring via the customizer
+
+If your server has an `apiKey` configured, the **GeoFilter tab** in the Customizer lets you edit the polygon visually without touching `config.json`:
+
+1. Open the Customizer (nav bar → customize icon)
+2. Click the **🗺️ GeoFilter** tab
+3. Click on the map to draw your polygon (at least 3 points)
+4. Adjust **Buffer km**
+5. Enter your **Server API Key** (the `apiKey` value from `config.json`)
+6. Click **Save to server** — the filter is applied immediately, no restart needed
+
+The editing controls only appear when the server has a write-capable API key configured. On deployments without an `apiKey`, the tab shows the current polygon as read-only.
+
+To remove the filter, click **Remove filter** (also requires the API key).
+
+## GeoFilter Builder (standalone tool)
+
+For a full-screen editing experience, use the built-in GeoFilter Builder at `/geofilter-builder.html`:
+
+1. Navigate to `http://your-server/geofilter-builder.html`
+2. Click on the map to add polygon vertices
+3. Adjust **Buffer km** (default 20)
+4. Copy the generated JSON from the output panel
+5. Paste it as a top-level key into `config.json` and restart the server
+
+The builder is also accessible from the Customizer's Export tab via the **GeoFilter Builder →** link.
+
+For local/offline use without a running server, open `tools/geofilter-builder.html` directly in a browser.
+
+## API endpoint
+
+```
+GET /api/config/geo-filter
+```
+
+Returns the current geo filter configuration. Also includes a `writeEnabled` boolean indicating whether the `PUT` endpoint is available (i.e., server has a write-capable `apiKey`).
+
+```
+PUT /api/config/geo-filter
+```
+
+Requires `X-API-Key` header. Saves the polygon to `config.json` and applies it in-memory immediately.
+
+Request body:
+```json
+{"polygon": [[lat, lon], ...], "bufferKm": 20}
+```
+
+To clear the filter, send `{"polygon": null}`.
+
+## Cleaning up historical nodes
+
+The ingestor prevents new out-of-bounds nodes from being ingested, but it does not retroactively remove nodes stored before the filter was configured. For that, use the prune script:
+
+**File:** `scripts/prune-nodes-outside-geo-filter.py`
+
+```bash
+# Dry run — shows what would be deleted without making changes
+python3 scripts/prune-nodes-outside-geo-filter.py --dry-run
+
+# Default paths: /app/data/meshcore.db and /app/config.json
+python3 scripts/prune-nodes-outside-geo-filter.py
+
+# Custom paths
+python3 scripts/prune-nodes-outside-geo-filter.py /path/to/meshcore.db \
+  --config /path/to/config.json
+
+# In Docker
+docker exec -it meshcore-analyzer \
+  python3 /app/scripts/prune-nodes-outside-geo-filter.py --dry-run
+```
+
+The script reads `geo_filter.polygon` and `geo_filter.bufferKm` from config, lists nodes that fall outside, then asks for `yes` confirmation before deleting. Nodes without coordinates are always kept.
+
+This is a **one-time migration tool** — run it once after first configuring `geo_filter` to clean up pre-filter data. The ingestor handles all subsequent filtering automatically.

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -782,6 +782,8 @@
 
   // GeoFilter tab state
   var _gfMap = null;
+  var _gfModalMap = null;
+  var _gfWriteEnabled = false;
   var _gfPoints = [];
   var _gfMarkers = [];
   var _gfPolygon = null;
@@ -1168,15 +1170,15 @@
     return '<div class="cust-panel' + (_activeTab === 'geofilter' ? ' active' : '') + '" data-panel="geofilter">' +
       '<p class="cust-section-title">Geographic Filter</p>' +
       '<p style="font-size:12px;color:var(--text-muted);margin-bottom:12px">Shows the active geographic filter. Nodes outside this area are excluded at ingest time and in API responses.</p>' +
-      '<div id="cv2-gf-map" style="height:220px;border-radius:6px;border:1px solid var(--border);margin-bottom:8px;background:var(--surface-1)"></div>' +
+      '<div style="position:relative;margin-bottom:8px">' +
+        '<div id="cv2-gf-map" style="height:200px;border-radius:6px;border:1px solid var(--border);background:var(--surface-1);cursor:pointer"></div>' +
+        '<div style="position:absolute;top:7px;right:7px;background:rgba(255,255,255,0.88);border-radius:4px;padding:3px 8px;font-size:11px;color:#444;pointer-events:none;box-shadow:0 1px 3px rgba(0,0,0,0.15)">🔍 click to expand</div>' +
+      '</div>' +
       '<div id="cv2-gf-status" style="font-size:12px;color:var(--text-muted);margin-bottom:10px">Loading current filter…</div>' +
       // Edit controls — hidden until server confirms write access (writeEnabled=true)
       '<div id="cv2-gf-edit" style="display:none">' +
-        '<p style="font-size:11px;color:var(--text-muted);margin-bottom:8px">Click the map to add polygon points. Need at least 3 points.</p>' +
         '<div style="display:flex;gap:8px;margin-bottom:10px;align-items:center">' +
-          '<button id="cv2-gf-undo" style="padding:5px 10px;background:var(--surface-1);color:var(--text-muted);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:12px">↩ Undo</button>' +
-          '<button id="cv2-gf-clear-pts" style="padding:5px 10px;background:var(--surface-1);color:var(--text-muted);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:12px">✕ Clear</button>' +
-          '<label style="font-size:12px;color:var(--text-muted);margin-left:auto">Buffer km:</label>' +
+          '<label style="font-size:12px;color:var(--text-muted)">Buffer km:</label>' +
           '<input type="number" id="cv2-gf-buffer" value="20" min="0" max="500" style="width:64px;padding:4px 8px;border:1px solid var(--border);border-radius:6px;background:var(--input-bg);color:var(--text);font-size:12px">' +
         '</div>' +
         '<div class="cust-field"><label>Server API Key</label>' +
@@ -1200,6 +1202,142 @@
         '</div>' +
       '</div>' +
     '</div>';
+  }
+
+  function _gfOpenModal(container) {
+    var existing = document.getElementById('cv2-gf-modal-overlay');
+    if (existing) existing.remove();
+    if (_gfModalMap) { _gfModalMap.remove(); _gfModalMap = null; }
+
+    var overlay = document.createElement('div');
+    overlay.id = 'cv2-gf-modal-overlay';
+    overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.65);z-index:99999;display:flex;align-items:center;justify-content:center;';
+
+    var dialog = document.createElement('div');
+    dialog.style.cssText = 'width:92vw;height:86vh;background:#fff;border-radius:10px;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,0.4);';
+
+    var toolbarEl = document.createElement('div');
+    toolbarEl.style.cssText = 'padding:10px 14px;display:flex;gap:8px;align-items:center;border-bottom:1px solid #e0e0e0;background:#f5f5f5;flex-shrink:0;';
+    var title = document.createElement('span');
+    title.style.cssText = 'font-weight:600;color:#333;font-size:14px;';
+    title.textContent = _gfWriteEnabled ? 'Edit GeoFilter — click map to add points' : 'GeoFilter — read only';
+    toolbarEl.appendChild(title);
+
+    if (_gfWriteEnabled) {
+      var undoBtn = document.createElement('button');
+      undoBtn.id = 'cv2-gfm-undo';
+      undoBtn.textContent = '↩ Undo';
+      undoBtn.style.cssText = 'padding:5px 10px;background:#eee;color:#555;border:1px solid #ccc;border-radius:6px;cursor:pointer;font-size:12px;';
+      var clearBtn = document.createElement('button');
+      clearBtn.id = 'cv2-gfm-clear';
+      clearBtn.textContent = '✕ Clear';
+      clearBtn.style.cssText = 'padding:5px 10px;background:#fee;color:#c44;border:1px solid #fcc;border-radius:6px;cursor:pointer;font-size:12px;';
+      var countEl = document.createElement('span');
+      countEl.id = 'cv2-gfm-count';
+      countEl.style.cssText = 'font-size:12px;color:#888;';
+      var spacer = document.createElement('span');
+      spacer.style.cssText = 'flex:1;';
+      var doneBtn = document.createElement('button');
+      doneBtn.id = 'cv2-gfm-done';
+      doneBtn.textContent = 'Done';
+      doneBtn.style.cssText = 'padding:7px 18px;background:#4a9eff;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:500;';
+      toolbarEl.appendChild(undoBtn);
+      toolbarEl.appendChild(clearBtn);
+      toolbarEl.appendChild(countEl);
+      toolbarEl.appendChild(spacer);
+      toolbarEl.appendChild(doneBtn);
+    } else {
+      var spacer2 = document.createElement('span');
+      spacer2.style.cssText = 'flex:1;';
+      toolbarEl.appendChild(spacer2);
+    }
+
+    var closeBtn = document.createElement('button');
+    closeBtn.id = 'cv2-gfm-close';
+    closeBtn.textContent = _gfWriteEnabled ? 'Cancel' : 'Close';
+    closeBtn.style.cssText = 'padding:7px 14px;background:#eee;color:#555;border:1px solid #ccc;border-radius:6px;cursor:pointer;font-size:13px;';
+    toolbarEl.appendChild(closeBtn);
+
+    var mapDiv = document.createElement('div');
+    mapDiv.id = 'cv2-gf-modal-map';
+    mapDiv.style.cssText = 'flex:1;';
+
+    dialog.appendChild(toolbarEl);
+    dialog.appendChild(mapDiv);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    var modalPoints = _gfPoints.map(function (p) { return [p[0], p[1]]; });
+    var modalMarkers = [];
+    var modalPolygon = null;
+    var modalClosingLine = null;
+
+    _gfModalMap = L.map(mapDiv, { zoomControl: true });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      attribution: '© OpenStreetMap © CartoDB', maxZoom: 19
+    }).addTo(_gfModalMap);
+
+    function renderModal() {
+      if (modalPolygon) { _gfModalMap.removeLayer(modalPolygon); modalPolygon = null; }
+      if (modalClosingLine) { _gfModalMap.removeLayer(modalClosingLine); modalClosingLine = null; }
+      modalMarkers.forEach(function (m) { _gfModalMap.removeLayer(m); });
+      modalMarkers = [];
+      modalPoints.forEach(function (pt, i) {
+        var m = L.circleMarker(pt, { radius: 6, color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.9 })
+          .addTo(_gfModalMap)
+          .bindTooltip(String(i + 1), { permanent: true, direction: 'top', offset: [0, -8] });
+        modalMarkers.push(m);
+      });
+      if (modalPoints.length >= 3) {
+        modalPolygon = L.polygon(modalPoints, { color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.12 }).addTo(_gfModalMap);
+      } else if (modalPoints.length === 2) {
+        modalClosingLine = L.polyline(modalPoints, { color: '#4a9eff', weight: 2, dashArray: '5,5' }).addTo(_gfModalMap);
+      }
+      var ce = document.getElementById('cv2-gfm-count');
+      if (ce) ce.textContent = modalPoints.length + ' point' + (modalPoints.length !== 1 ? 's' : '');
+    }
+
+    function closeModal() {
+      if (_gfModalMap) { _gfModalMap.remove(); _gfModalMap = null; }
+      overlay.remove();
+    }
+
+    setTimeout(function () {
+      _gfModalMap.invalidateSize();
+      renderModal();
+      if (modalPoints.length >= 3) {
+        _gfModalMap.fitBounds(L.latLngBounds(modalPoints), { padding: [40, 40] });
+      } else {
+        _gfModalMap.setView([50.5, 4.4], 5);
+      }
+    }, 80);
+
+    if (_gfWriteEnabled) {
+      _gfModalMap.on('click', function (e) {
+        modalPoints.push([parseFloat(e.latlng.lat.toFixed(6)), parseFloat(e.latlng.lng.toFixed(6))]);
+        renderModal();
+      });
+      document.getElementById('cv2-gfm-undo').addEventListener('click', function () {
+        if (!modalPoints.length) return;
+        modalPoints.pop();
+        renderModal();
+      });
+      document.getElementById('cv2-gfm-clear').addEventListener('click', function () {
+        modalPoints = [];
+        renderModal();
+      });
+      document.getElementById('cv2-gfm-done').addEventListener('click', function () {
+        _gfPoints = modalPoints;
+        _gfRender();
+        var prune = container.querySelector('#cv2-gf-prune-section');
+        if (prune) prune.style.display = _gfPoints.length >= 3 ? '' : 'none';
+        _gfStatus(container, _gfPoints.length + ' point' + (_gfPoints.length !== 1 ? 's' : '') + '.');
+        closeModal();
+      });
+    }
+
+    closeBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', function (e) { if (e.target === overlay) closeModal(); });
   }
 
   function _gfRender() {
@@ -1340,8 +1478,8 @@
     var mapEl = container.querySelector('#cv2-gf-map');
     if (!mapEl || typeof L === 'undefined') return;
 
-    _gfMap = L.map(mapEl, { zoomControl: true });
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+    _gfMap = L.map(mapEl, { zoomControl: false, dragging: false, scrollWheelZoom: false, doubleClickZoom: false, touchZoom: false });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
       attribution: '© OpenStreetMap © CartoDB', maxZoom: 19
     }).addTo(_gfMap);
 
@@ -1349,6 +1487,7 @@
       api('/config/geo-filter', { ttl: 0 }).then(function (gf) {
         // Show edit controls only on servers that have a write-capable API key configured
         if (gf && gf.writeEnabled) {
+          _gfWriteEnabled = true;
           var editEl = container.querySelector('#cv2-gf-edit');
           if (editEl) editEl.style.display = '';
         }
@@ -1366,7 +1505,7 @@
           }
         } else {
           _gfPoints = [];
-          _gfStatus(container, gf && gf.writeEnabled ? 'No geo filter. Click the map to draw a polygon.' : 'No geo filter configured.');
+          _gfStatus(container, gf && gf.writeEnabled ? 'No geo filter. Click the map to open the editor.' : 'No geo filter configured.');
           _gfMap.setView([50.5, 4.4], 5);
         }
         _gfLoaded = true;
@@ -1390,23 +1529,8 @@
       setTimeout(function () { if (_gfMap) _gfMap.invalidateSize(); }, 100);
     }
 
-    _gfMap.on('click', function (e) {
-      _gfPoints.push([parseFloat(e.latlng.lat.toFixed(6)), parseFloat(e.latlng.lng.toFixed(6))]);
-      _gfRender();
-      _gfStatus(container, _gfPoints.length + ' point' + (_gfPoints.length !== 1 ? 's' : '') + '.');
-    });
+    _gfMap.on('click', function () { _gfOpenModal(container); });
 
-    container.querySelector('#cv2-gf-undo').addEventListener('click', function () {
-      if (!_gfPoints.length) return;
-      _gfPoints.pop();
-      _gfRender();
-      _gfStatus(container, _gfPoints.length + ' point' + (_gfPoints.length !== 1 ? 's' : '') + '.');
-    });
-    container.querySelector('#cv2-gf-clear-pts').addEventListener('click', function () {
-      _gfPoints = [];
-      _gfRender();
-      _gfStatus(container, 'Cleared. Click the map to draw a polygon.');
-    });
     container.querySelector('#cv2-gf-save').addEventListener('click', function () { _gfSave(container); });
     container.querySelector('#cv2-gf-remove').addEventListener('click', function () { _gfRemove(container); });
 
@@ -1519,7 +1643,7 @@
     // Tab switching
     container.querySelectorAll('.cust-tab').forEach(function (btn) {
       btn.addEventListener('click', function () {
-        if (_gfMap) { _gfMap.remove(); _gfMap = null; _gfMarkers = []; _gfPolygon = null; _gfClosingLine = null; }
+        if (_gfMap) { _gfMap.remove(); _gfMap = null; _gfMarkers = []; _gfPolygon = null; _gfClosingLine = null; } if (_gfModalMap) { _gfModalMap.remove(); _gfModalMap = null; } var _ov = document.getElementById('cv2-gf-modal-overlay'); if (_ov) _ov.remove();
         _activeTab = btn.dataset.tab;
         _renderPanel(container);
       });
@@ -1793,7 +1917,7 @@
     document.body.appendChild(_panelEl);
 
     _panelEl.querySelector('.cust-close').addEventListener('click', function () {
-      if (_gfMap) { _gfMap.remove(); _gfMap = null; _gfMarkers = []; _gfPolygon = null; _gfClosingLine = null; }
+      if (_gfMap) { _gfMap.remove(); _gfMap = null; _gfMarkers = []; _gfPolygon = null; _gfClosingLine = null; } if (_gfModalMap) { _gfModalMap.remove(); _gfModalMap = null; } var _ov = document.getElementById('cv2-gf-modal-overlay'); if (_ov) _ov.remove();
       _panelEl.classList.add('hidden');
     });
 

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -780,6 +780,14 @@
   var _activeTab = 'branding';
   var _styleEl = null;
 
+  // GeoFilter tab state
+  var _gfMap = null;
+  var _gfPoints = [];
+  var _gfMarkers = [];
+  var _gfPolygon = null;
+  var _gfClosingLine = null;
+  var _gfLoaded = false; // true after initial server load
+
   function esc(s) { var d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
   function escAttr(s) { return (s || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;'); }
 
@@ -906,6 +914,7 @@
       { id: 'nodes', label: '🎯', title: 'Colors', badge: (function () { var n = _countOverrides('nodeColors') + _countOverrides('typeColors'); return n ? ' <span class="cv2-tab-badge">' + n + '</span>' : ''; })() },
       { id: 'home', label: '🏠', title: 'Home', badge: _tabBadge('home') },
       { id: 'display', label: '🖥️', title: 'Display', badge: (function () { var n = _countOverrides('timestamps') + (_isOverridden(null, 'distanceUnit') ? 1 : 0); return n ? ' <span class="cv2-tab-badge">' + n + '</span>' : ''; })() },
+      { id: 'geofilter', label: '🗺️', title: 'GeoFilter' },
       { id: 'export', label: '📤', title: 'Export' }
     ];
     return '<div class="cust-tabs">' + tabs.map(function (t) {
@@ -1155,6 +1164,170 @@
     '</div>';
   }
 
+  function _renderGeoFilter() {
+    return '<div class="cust-panel' + (_activeTab === 'geofilter' ? ' active' : '') + '" data-panel="geofilter">' +
+      '<p class="cust-section-title">Geographic Filter</p>' +
+      '<p style="font-size:12px;color:var(--text-muted);margin-bottom:12px">Shows the active geographic filter. Nodes outside this area are excluded at ingest time and in API responses.</p>' +
+      '<div id="cv2-gf-map" style="height:220px;border-radius:6px;border:1px solid var(--border);margin-bottom:8px;background:var(--surface-1)"></div>' +
+      '<div id="cv2-gf-status" style="font-size:12px;color:var(--text-muted);margin-bottom:10px">Loading current filter…</div>' +
+      // Edit controls — hidden until server confirms write access (writeEnabled=true)
+      '<div id="cv2-gf-edit" style="display:none">' +
+        '<p style="font-size:11px;color:var(--text-muted);margin-bottom:8px">Click the map to add polygon points. Need at least 3 points.</p>' +
+        '<div style="display:flex;gap:8px;margin-bottom:10px;align-items:center">' +
+          '<button id="cv2-gf-undo" style="padding:5px 10px;background:var(--surface-1);color:var(--text-muted);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:12px">↩ Undo</button>' +
+          '<button id="cv2-gf-clear-pts" style="padding:5px 10px;background:var(--surface-1);color:var(--text-muted);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:12px">✕ Clear</button>' +
+          '<label style="font-size:12px;color:var(--text-muted);margin-left:auto">Buffer km:</label>' +
+          '<input type="number" id="cv2-gf-buffer" value="20" min="0" max="500" style="width:64px;padding:4px 8px;border:1px solid var(--border);border-radius:6px;background:var(--input-bg);color:var(--text);font-size:12px">' +
+        '</div>' +
+        '<div class="cust-field"><label>Server API Key</label>' +
+          '<input type="password" id="cv2-gf-apikey" placeholder="apiKey from config.json" style="width:100%;padding:5px 8px;border:1px solid var(--border);border-radius:6px;background:var(--input-bg);color:var(--text);font-size:12px">' +
+        '</div>' +
+        '<div style="display:flex;gap:8px;margin-top:12px">' +
+          '<button id="cv2-gf-save" style="padding:7px 16px;background:var(--accent);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:13px;font-weight:500">Save to server</button>' +
+          '<button id="cv2-gf-remove" style="padding:7px 14px;background:var(--surface-1);color:var(--status-red);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:13px">Remove filter</button>' +
+        '</div>' +
+        '<div id="cv2-gf-msg" style="margin-top:8px;font-size:12px;display:none"></div>' +
+      '</div>' +
+    '</div>';
+  }
+
+  function _gfRender() {
+    if (!_gfMap) return;
+    if (_gfPolygon) { _gfMap.removeLayer(_gfPolygon); _gfPolygon = null; }
+    if (_gfClosingLine) { _gfMap.removeLayer(_gfClosingLine); _gfClosingLine = null; }
+    _gfMarkers.forEach(function (m) { _gfMap.removeLayer(m); });
+    _gfMarkers = [];
+
+    _gfPoints.forEach(function (pt, i) {
+      var m = L.circleMarker(pt, { radius: 6, color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.9 })
+        .addTo(_gfMap)
+        .bindTooltip(String(i + 1), { permanent: true, direction: 'top', offset: [0, -8] });
+      _gfMarkers.push(m);
+    });
+
+    if (_gfPoints.length >= 3) {
+      _gfPolygon = L.polygon(_gfPoints, { color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.12 }).addTo(_gfMap);
+    } else if (_gfPoints.length === 2) {
+      _gfClosingLine = L.polyline(_gfPoints, { color: '#4a9eff', weight: 2, dashArray: '5,5' }).addTo(_gfMap);
+    }
+  }
+
+  function _gfStatus(container, msg) {
+    var el = container.querySelector('#cv2-gf-status');
+    if (el) el.textContent = msg;
+  }
+
+  function _gfMsg(container, msg, ok) {
+    var el = container.querySelector('#cv2-gf-msg');
+    if (!el) return;
+    el.textContent = msg;
+    el.style.display = msg ? '' : 'none';
+    el.style.color = ok ? 'var(--status-green)' : 'var(--status-red)';
+  }
+
+  function _gfSave(container) {
+    if (_gfPoints.length < 3) { _gfMsg(container, 'Need at least 3 polygon points.', false); return; }
+    var apiKey = (container.querySelector('#cv2-gf-apikey') || {}).value || '';
+    if (!apiKey) { _gfMsg(container, 'API key required to save.', false); return; }
+    var bufferKm = parseFloat((container.querySelector('#cv2-gf-buffer') || {}).value) || 0;
+    fetch('/api/config/geo-filter', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+      body: JSON.stringify({ polygon: _gfPoints, bufferKm: bufferKm })
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (e) { throw new Error(e.error || ('HTTP ' + r.status)); });
+      _gfMsg(container, 'Saved. Filter is active immediately.', true);
+      _gfStatus(container, _gfPoints.length + ' points · bufferKm=' + bufferKm + ' · saved');
+    }).catch(function (e) { _gfMsg(container, 'Error: ' + e.message, false); });
+  }
+
+  function _gfRemove(container) {
+    var apiKey = (container.querySelector('#cv2-gf-apikey') || {}).value || '';
+    if (!apiKey) { _gfMsg(container, 'API key required.', false); return; }
+    if (!confirm('Remove geo filter? All nodes will be allowed through.')) return;
+    fetch('/api/config/geo-filter', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+      body: JSON.stringify({ polygon: null })
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (e) { throw new Error(e.error || ('HTTP ' + r.status)); });
+      _gfPoints = []; _gfLoaded = true;
+      _gfRender();
+      _gfStatus(container, 'No geo filter. Click the map to draw a polygon.');
+      _gfMsg(container, 'Geo filter removed.', true);
+    }).catch(function (e) { _gfMsg(container, 'Error: ' + e.message, false); });
+  }
+
+  function _initGeoFilterTab(container) {
+    var mapEl = container.querySelector('#cv2-gf-map');
+    if (!mapEl || typeof L === 'undefined') return;
+
+    _gfMap = L.map(mapEl, { zoomControl: true });
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+      attribution: '© OpenStreetMap © CartoDB', maxZoom: 19
+    }).addTo(_gfMap);
+
+    if (!_gfLoaded) {
+      api('/config/geo-filter', { ttl: 0 }).then(function (gf) {
+        // Show edit controls only on servers that have a write-capable API key configured
+        if (gf && gf.writeEnabled) {
+          var editEl = container.querySelector('#cv2-gf-edit');
+          if (editEl) editEl.style.display = '';
+        }
+        if (gf && gf.polygon && gf.polygon.length >= 3) {
+          _gfPoints = gf.polygon.map(function (p) { return [p[0], p[1]]; });
+          var buf = container.querySelector('#cv2-gf-buffer');
+          if (buf) buf.value = gf.bufferKm || 0;
+          _gfRender();
+          if (_gfPolygon) _gfMap.fitBounds(_gfPolygon.getBounds(), { padding: [20, 20] });
+          _gfStatus(container, gf.polygon.length + ' points · bufferKm=' + (gf.bufferKm || 0));
+        } else {
+          _gfPoints = [];
+          _gfStatus(container, gf && gf.writeEnabled ? 'No geo filter. Click the map to draw a polygon.' : 'No geo filter configured.');
+          _gfMap.setView([50.5, 4.4], 5);
+        }
+        _gfLoaded = true;
+        setTimeout(function () { if (_gfMap) _gfMap.invalidateSize(); }, 100);
+      }).catch(function () {
+        _gfStatus(container, 'Could not load current filter.');
+        _gfMap.setView([50.5, 4.4], 5);
+        _gfLoaded = true;
+        setTimeout(function () { if (_gfMap) _gfMap.invalidateSize(); }, 100);
+      });
+    } else {
+      if (_gfPoints.length >= 3) {
+        _gfRender();
+        if (_gfPolygon) _gfMap.fitBounds(_gfPolygon.getBounds(), { padding: [20, 20] });
+        _gfStatus(container, _gfPoints.length + ' points.');
+      } else {
+        _gfMap.setView([50.5, 4.4], 5);
+        _gfStatus(container, _gfPoints.length ? _gfPoints.length + ' points (need at least 3).' : 'Click the map to draw a polygon.');
+        _gfRender();
+      }
+      setTimeout(function () { if (_gfMap) _gfMap.invalidateSize(); }, 100);
+    }
+
+    _gfMap.on('click', function (e) {
+      _gfPoints.push([parseFloat(e.latlng.lat.toFixed(6)), parseFloat(e.latlng.lng.toFixed(6))]);
+      _gfRender();
+      _gfStatus(container, _gfPoints.length + ' point' + (_gfPoints.length !== 1 ? 's' : '') + '.');
+    });
+
+    container.querySelector('#cv2-gf-undo').addEventListener('click', function () {
+      if (!_gfPoints.length) return;
+      _gfPoints.pop();
+      _gfRender();
+      _gfStatus(container, _gfPoints.length + ' point' + (_gfPoints.length !== 1 ? 's' : '') + '.');
+    });
+    container.querySelector('#cv2-gf-clear-pts').addEventListener('click', function () {
+      _gfPoints = [];
+      _gfRender();
+      _gfStatus(container, 'Cleared. Click the map to draw a polygon.');
+    });
+    container.querySelector('#cv2-gf-save').addEventListener('click', function () { _gfSave(container); });
+    container.querySelector('#cv2-gf-remove').addEventListener('click', function () { _gfRemove(container); });
+  }
+
   function _renderExport() {
     var delta = readOverrides();
     var json = JSON.stringify(delta, null, 2);
@@ -1185,6 +1358,7 @@
         _renderNodes() +
         _renderHome() +
         _renderDisplay() +
+        _renderGeoFilter() +
         _renderExport() +
       '</div>';
     _bindEvents(container);
@@ -1253,10 +1427,14 @@
     // Tab switching
     container.querySelectorAll('.cust-tab').forEach(function (btn) {
       btn.addEventListener('click', function () {
+        if (_gfMap) { _gfMap.remove(); _gfMap = null; _gfMarkers = []; _gfPolygon = null; _gfClosingLine = null; }
         _activeTab = btn.dataset.tab;
         _renderPanel(container);
       });
     });
+
+    // GeoFilter tab init
+    if (_activeTab === 'geofilter') _initGeoFilterTab(container);
 
     // Preset buttons
     container.querySelectorAll('.cust-preset-btn').forEach(function (btn) {
@@ -1522,7 +1700,10 @@
       '<div class="cv2-footer"><span id="cv2-save-status">All changes saved</span></div>';
     document.body.appendChild(_panelEl);
 
-    _panelEl.querySelector('.cust-close').addEventListener('click', function () { _panelEl.classList.add('hidden'); });
+    _panelEl.querySelector('.cust-close').addEventListener('click', function () {
+      if (_gfMap) { _gfMap.remove(); _gfMap = null; _gfMarkers = []; _gfPolygon = null; _gfClosingLine = null; }
+      _panelEl.classList.add('hidden');
+    });
 
     // Drag support
     var header = _panelEl.querySelector('.cust-header');

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1173,6 +1173,10 @@
       '<details style="margin-top:12px"><summary style="font-size:12px;font-weight:600;cursor:pointer;color:var(--text-muted)">Raw JSON</summary>' +
         '<textarea id="cv2ExportJson" style="width:100%;min-height:200px;font-family:var(--mono);font-size:12px;background:var(--surface-1);border:1px solid var(--border);border-radius:6px;padding:12px;color:var(--text);resize:vertical;box-sizing:border-box;margin-top:8px">' + esc(json) + '</textarea>' +
       '</details>' +
+      '<p class="cust-section-title" style="margin-top:20px">Tools</p>' +
+      '<p style="font-size:12px;color:var(--text-muted);margin-bottom:10px">Server-side configuration helpers.</p>' +
+      '<a href="/geofilter-builder.html" target="_blank" style="display:inline-block;padding:7px 14px;background:var(--surface-1);border:1px solid var(--border);border-radius:6px;color:var(--accent);font-size:13px;text-decoration:none;font-weight:500">🗺️ GeoFilter Builder →</a>' +
+      '<p style="font-size:11px;color:var(--text-muted);margin-top:6px">Draw a polygon on the map to generate a <code style="font-family:var(--mono)">geo_filter</code> block for <code style="font-family:var(--mono)">config.json</code>.</p>' +
     '</div>';
   }
 

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1187,6 +1187,17 @@
           '<button id="cv2-gf-remove" style="padding:7px 14px;background:var(--surface-1);color:var(--status-red);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:13px">Remove filter</button>' +
         '</div>' +
         '<div id="cv2-gf-msg" style="margin-top:8px;font-size:12px;display:none"></div>' +
+        // Prune section — only shown when a polygon is active (toggled in _initGeoFilterTab)
+        '<div id="cv2-gf-prune-section" style="display:none;margin-top:16px;border-top:1px solid var(--border);padding-top:14px">' +
+          '<p class="cust-section-title" style="font-size:13px;margin-bottom:6px">Prune historical nodes</p>' +
+          '<p style="font-size:11px;color:var(--text-muted);margin-bottom:10px">Remove nodes already in the database that fall outside the current filter. Run once after first enabling geo filtering.</p>' +
+          '<button id="cv2-gf-prune-preview" style="padding:6px 14px;background:var(--surface-1);color:var(--text-muted);border:1px solid var(--border);border-radius:6px;cursor:pointer;font-size:12px">Preview prune</button>' +
+          '<div id="cv2-gf-prune-result" style="display:none;margin-top:10px">' +
+            '<div id="cv2-gf-prune-list" style="font-size:11px;color:var(--text-muted);max-height:100px;overflow-y:auto;margin-bottom:8px;background:var(--surface-1);border:1px solid var(--border);border-radius:4px;padding:6px 8px"></div>' +
+            '<button id="cv2-gf-prune-confirm" style="padding:6px 14px;background:var(--status-red);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:12px;font-weight:500">Delete nodes</button>' +
+          '</div>' +
+          '<div id="cv2-gf-prune-msg" style="margin-top:8px;font-size:12px;display:none"></div>' +
+        '</div>' +
       '</div>' +
     '</div>';
   }
@@ -1258,6 +1269,73 @@
     }).catch(function (e) { _gfMsg(container, 'Error: ' + e.message, false); });
   }
 
+  var _gfPruneNodes = []; // nodes returned by last dry-run preview
+
+  function _gfPruneMsg(container, msg, ok) {
+    var el = container.querySelector('#cv2-gf-prune-msg');
+    if (!el) return;
+    el.textContent = msg;
+    el.style.display = msg ? '' : 'none';
+    el.style.color = ok ? 'var(--status-green)' : 'var(--status-red)';
+  }
+
+  function _gfPrunePreview(container) {
+    var apiKey = (container.querySelector('#cv2-gf-apikey') || {}).value || '';
+    if (!apiKey) { _gfPruneMsg(container, 'API key required.', false); return; }
+    var btn = container.querySelector('#cv2-gf-prune-preview');
+    if (btn) btn.textContent = 'Loading…';
+    fetch('/api/admin/prune-geo-filter', {
+      method: 'POST',
+      headers: { 'X-API-Key': apiKey }
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (e) { throw new Error(e.error || ('HTTP ' + r.status)); });
+      return r.json();
+    }).then(function (data) {
+      if (btn) btn.textContent = 'Preview prune';
+      _gfPruneNodes = data.nodes || [];
+      var count = data.count || 0;
+      var resultEl = container.querySelector('#cv2-gf-prune-result');
+      var listEl = container.querySelector('#cv2-gf-prune-list');
+      var confirmBtn = container.querySelector('#cv2-gf-prune-confirm');
+      if (!resultEl || !listEl || !confirmBtn) return;
+      if (count === 0) {
+        _gfPruneMsg(container, 'No nodes outside the filter. Nothing to prune.', true);
+        resultEl.style.display = 'none';
+        return;
+      }
+      listEl.innerHTML = _gfPruneNodes.map(function (n) {
+        var coords = n.lat != null ? (' · ' + n.lat.toFixed(4) + ', ' + n.lon.toFixed(4)) : '';
+        return '<div>' + (n.name || n.pubkey.slice(0, 12)) + coords + '</div>';
+      }).join('');
+      confirmBtn.textContent = 'Delete ' + count + ' node' + (count !== 1 ? 's' : '');
+      resultEl.style.display = '';
+      _gfPruneMsg(container, '', true);
+    }).catch(function (e) {
+      if (btn) btn.textContent = 'Preview prune';
+      _gfPruneMsg(container, 'Error: ' + e.message, false);
+    });
+  }
+
+  function _gfPruneConfirm(container) {
+    if (!_gfPruneNodes.length) { _gfPruneMsg(container, 'Run preview first.', false); return; }
+    var apiKey = (container.querySelector('#cv2-gf-apikey') || {}).value || '';
+    if (!apiKey) { _gfPruneMsg(container, 'API key required.', false); return; }
+    var count = _gfPruneNodes.length;
+    if (!confirm('Delete ' + count + ' node' + (count !== 1 ? 's' : '') + ' from the database? This cannot be undone.')) return;
+    fetch('/api/admin/prune-geo-filter?confirm=true', {
+      method: 'POST',
+      headers: { 'X-API-Key': apiKey }
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (e) { throw new Error(e.error || ('HTTP ' + r.status)); });
+      return r.json();
+    }).then(function (data) {
+      _gfPruneNodes = [];
+      var resultEl = container.querySelector('#cv2-gf-prune-result');
+      if (resultEl) resultEl.style.display = 'none';
+      _gfPruneMsg(container, 'Deleted ' + data.deleted + ' node' + (data.deleted !== 1 ? 's' : '') + '.', true);
+    }).catch(function (e) { _gfPruneMsg(container, 'Error: ' + e.message, false); });
+  }
+
   function _initGeoFilterTab(container) {
     var mapEl = container.querySelector('#cv2-gf-map');
     if (!mapEl || typeof L === 'undefined') return;
@@ -1281,6 +1359,11 @@
           _gfRender();
           if (_gfPolygon) _gfMap.fitBounds(_gfPolygon.getBounds(), { padding: [20, 20] });
           _gfStatus(container, gf.polygon.length + ' points · bufferKm=' + (gf.bufferKm || 0));
+          // Show prune section when a polygon is active and write access is available
+          if (gf.writeEnabled) {
+            var pruneEl = container.querySelector('#cv2-gf-prune-section');
+            if (pruneEl) pruneEl.style.display = '';
+          }
         } else {
           _gfPoints = [];
           _gfStatus(container, gf && gf.writeEnabled ? 'No geo filter. Click the map to draw a polygon.' : 'No geo filter configured.');
@@ -1326,6 +1409,11 @@
     });
     container.querySelector('#cv2-gf-save').addEventListener('click', function () { _gfSave(container); });
     container.querySelector('#cv2-gf-remove').addEventListener('click', function () { _gfRemove(container); });
+
+    var prunePreviewBtn = container.querySelector('#cv2-gf-prune-preview');
+    var pruneConfirmBtn = container.querySelector('#cv2-gf-prune-confirm');
+    if (prunePreviewBtn) prunePreviewBtn.addEventListener('click', function () { _gfPrunePreview(container); });
+    if (pruneConfirmBtn) pruneConfirmBtn.addEventListener('click', function () { _gfPruneConfirm(container); });
   }
 
   function _renderExport() {

--- a/public/geofilter-builder.html
+++ b/public/geofilter-builder.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GeoFilter Builder — CoreScope</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; height: 100vh; display: flex; flex-direction: column; }
+  header { padding: 12px 16px; background: #0f0f23; border-bottom: 1px solid #333; display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+  header h1 { font-size: 1rem; font-weight: 600; color: #4a9eff; white-space: nowrap; }
+  .controls { display: flex; gap: 8px; flex-wrap: wrap; }
+  button { padding: 6px 14px; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; font-weight: 500; }
+  #btnUndo  { background: #333; color: #ccc; }
+  #btnClear { background: #5a2020; color: #ffaaaa; }
+  #btnUndo:hover  { background: #444; }
+  #btnClear:hover { background: #7a2020; }
+  .hint { font-size: 0.8rem; color: #888; margin-left: auto; }
+  #map { flex: 1; }
+  #output-panel { background: #0f0f23; border-top: 1px solid #333; padding: 12px 16px; display: flex; gap: 12px; align-items: flex-start; }
+  #output-panel label { font-size: 0.75rem; color: #888; white-space: nowrap; padding-top: 6px; }
+  #output { flex: 1; background: #111; border: 1px solid #333; border-radius: 6px; padding: 10px 12px; font-family: monospace; font-size: 0.78rem; color: #7ec8e3; white-space: pre; overflow-x: auto; min-height: 54px; max-height: 140px; overflow-y: auto; cursor: text; }
+  #output.empty { color: #555; font-style: italic; }
+  #btnCopy { padding: 6px 14px; background: #1a4a7a; color: #7ec8e3; border-radius: 6px; border: none; cursor: pointer; font-size: 0.85rem; white-space: nowrap; align-self: flex-end; }
+  #btnCopy:hover { background: #2a6aaa; }
+  #btnCopy.copied { background: #1a6a3a; color: #7effa0; }
+  #counter { font-size: 0.8rem; color: #888; padding-top: 6px; white-space: nowrap; }
+  .bufferRow { display: flex; align-items: center; gap: 8px; }
+  .bufferRow label { font-size: 0.85rem; color: #aaa; }
+  .bufferRow input { width: 60px; padding: 5px 8px; background: #222; border: 1px solid #444; border-radius: 6px; color: #eee; font-size: 0.85rem; }
+  #help-bar { background: #0f0f23; padding: 6px 16px; font-size: 0.75rem; color: #666; border-top: 1px solid #222; }
+  #help-bar a { color: #4a9eff; text-decoration: none; }
+  #help-bar a:hover { text-decoration: underline; }
+  #back-link { font-size: 0.8rem; color: #4a9eff; text-decoration: none; white-space: nowrap; }
+  #back-link:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<header>
+  <a href="/" id="back-link">← CoreScope</a>
+  <h1>GeoFilter Builder</h1>
+  <div class="controls">
+    <button id="btnUndo">↩ Undo</button>
+    <button id="btnClear">✕ Clear</button>
+  </div>
+  <div class="bufferRow">
+    <label for="bufferKm">Buffer km:</label>
+    <!-- Extra margin (km) outside the polygon edge that still passes the filter -->
+    <input type="number" id="bufferKm" value="20" min="0" max="500"/>
+  </div>
+  <span class="hint">Click on the map to add polygon points</span>
+</header>
+
+<div id="map"></div>
+
+<!-- Output panel: shows the geo_filter JSON block ready to paste into config.json -->
+<div id="output-panel">
+  <label>config.json</label>
+  <div id="output" class="empty">Add at least 3 points to generate config…</div>
+  <div style="display:flex;flex-direction:column;gap:8px;align-items:flex-end">
+    <span id="counter">0 points</span>
+    <button id="btnCopy">Copy</button>
+  </div>
+</div>
+
+<!-- Instructions: paste the output into config.json as a top-level "geo_filter" key, then restart the server -->
+<div id="help-bar">
+  Copy the JSON above → paste as a top-level key in <code>config.json</code> → restart the server.
+  Nodes with no GPS fix always pass through. Remove the <code>geo_filter</code> block to disable filtering.
+  &nbsp;·&nbsp; <a href="https://github.com/Kpa-clawbot/CoreScope/blob/master/docs/user-guide/geofilter.md" target="_blank">Documentation ↗</a>
+</div>
+
+<script>
+const map = L.map('map').setView([50.5, 4.4], 8);
+
+L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+  attribution: '© OpenStreetMap © CartoDB',
+  maxZoom: 19
+}).addTo(map);
+
+let points = [];
+let markers = [];
+let polygon = null;
+let closingLine = null;
+
+function latLonPair(latlng) {
+  return [parseFloat(latlng.lat.toFixed(6)), parseFloat(latlng.lng.toFixed(6))];
+}
+
+function render() {
+  // Remove existing polygon and closing line
+  if (polygon) { map.removeLayer(polygon); polygon = null; }
+  if (closingLine) { map.removeLayer(closingLine); closingLine = null; }
+
+  if (points.length >= 3) {
+    polygon = L.polygon(points, {
+      color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.12
+    }).addTo(map);
+  } else if (points.length === 2) {
+    closingLine = L.polyline(points, { color: '#4a9eff', weight: 2, dashArray: '5,5' }).addTo(map);
+  }
+
+  updateOutput();
+}
+
+function updateOutput() {
+  const el = document.getElementById('output');
+  const counter = document.getElementById('counter');
+  counter.textContent = points.length + ' point' + (points.length !== 1 ? 's' : '');
+
+  if (points.length < 3) {
+    el.textContent = 'Add at least 3 points to generate config…';
+    el.classList.add('empty');
+    return;
+  }
+  el.classList.remove('empty');
+
+  const bufferKm = parseFloat(document.getElementById('bufferKm').value) || 0;
+  // Output format: { "geo_filter": { "bufferKm": N, "polygon": [[lat,lon], ...] } }
+  // Paste this as a top-level key in config.json
+  const config = { bufferKm, polygon: points };
+  el.textContent = JSON.stringify({ geo_filter: config }, null, 2);
+}
+
+map.on('click', function(e) {
+  const pt = latLonPair(e.latlng);
+  points.push(pt);
+
+  const idx = points.length;
+  const marker = L.circleMarker(e.latlng, {
+    radius: 6, color: '#4a9eff', weight: 2, fillColor: '#4a9eff', fillOpacity: 0.9
+  }).addTo(map).bindTooltip(String(idx), { permanent: true, direction: 'top', offset: [0, -8], className: 'pt-label' });
+  markers.push(marker);
+
+  render();
+});
+
+document.getElementById('btnUndo').addEventListener('click', function() {
+  if (!points.length) return;
+  points.pop();
+  const m = markers.pop();
+  if (m) map.removeLayer(m);
+  render();
+});
+
+document.getElementById('btnClear').addEventListener('click', function() {
+  points = [];
+  markers.forEach(m => map.removeLayer(m));
+  markers = [];
+  render();
+});
+
+document.getElementById('bufferKm').addEventListener('input', updateOutput);
+
+document.getElementById('btnCopy').addEventListener('click', function() {
+  if (points.length < 3) return;
+  const text = document.getElementById('output').textContent;
+  navigator.clipboard.writeText(text).then(() => {
+    const btn = document.getElementById('btnCopy');
+    btn.textContent = 'Copied!';
+    btn.classList.add('copied');
+    setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 2000);
+  });
+});
+</script>
+</body>
+</html>

--- a/public/geofilter-builder.html
+++ b/public/geofilter-builder.html
@@ -8,32 +8,32 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: system-ui, sans-serif; background: #1a1a2e; color: #e0e0e0; height: 100vh; display: flex; flex-direction: column; }
-  header { padding: 12px 16px; background: #0f0f23; border-bottom: 1px solid #333; display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
-  header h1 { font-size: 1rem; font-weight: 600; color: #4a9eff; white-space: nowrap; }
+  body { font-family: system-ui, sans-serif; background: #f5f5f5; color: #222; height: 100vh; display: flex; flex-direction: column; }
+  header { padding: 12px 16px; background: #fff; border-bottom: 1px solid #ddd; display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+  header h1 { font-size: 1rem; font-weight: 600; color: #1a6abf; white-space: nowrap; }
   .controls { display: flex; gap: 8px; flex-wrap: wrap; }
   button { padding: 6px 14px; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem; font-weight: 500; }
-  #btnUndo  { background: #333; color: #ccc; }
-  #btnClear { background: #5a2020; color: #ffaaaa; }
-  #btnUndo:hover  { background: #444; }
-  #btnClear:hover { background: #7a2020; }
+  #btnUndo  { background: #eee; color: #555; border: 1px solid #ccc; }
+  #btnClear { background: #fee; color: #c44; border: 1px solid #fcc; }
+  #btnUndo:hover  { background: #e0e0e0; }
+  #btnClear:hover { background: #fdd; }
   .hint { font-size: 0.8rem; color: #888; margin-left: auto; }
   #map { flex: 1; }
-  #output-panel { background: #0f0f23; border-top: 1px solid #333; padding: 12px 16px; display: flex; gap: 12px; align-items: flex-start; }
+  #output-panel { background: #fff; border-top: 1px solid #ddd; padding: 12px 16px; display: flex; gap: 12px; align-items: flex-start; }
   #output-panel label { font-size: 0.75rem; color: #888; white-space: nowrap; padding-top: 6px; }
-  #output { flex: 1; background: #111; border: 1px solid #333; border-radius: 6px; padding: 10px 12px; font-family: monospace; font-size: 0.78rem; color: #7ec8e3; white-space: pre; overflow-x: auto; min-height: 54px; max-height: 140px; overflow-y: auto; cursor: text; }
-  #output.empty { color: #555; font-style: italic; }
-  #btnCopy { padding: 6px 14px; background: #1a4a7a; color: #7ec8e3; border-radius: 6px; border: none; cursor: pointer; font-size: 0.85rem; white-space: nowrap; align-self: flex-end; }
-  #btnCopy:hover { background: #2a6aaa; }
-  #btnCopy.copied { background: #1a6a3a; color: #7effa0; }
+  #output { flex: 1; background: #f0f4f8; border: 1px solid #ccd; border-radius: 6px; padding: 10px 12px; font-family: monospace; font-size: 0.78rem; color: #1a6abf; white-space: pre; overflow-x: auto; min-height: 54px; max-height: 140px; overflow-y: auto; cursor: text; }
+  #output.empty { color: #aaa; font-style: italic; }
+  #btnCopy { padding: 6px 14px; background: #1a6abf; color: #fff; border-radius: 6px; border: none; cursor: pointer; font-size: 0.85rem; white-space: nowrap; align-self: flex-end; }
+  #btnCopy:hover { background: #1558a0; }
+  #btnCopy.copied { background: #1a7a3a; color: #fff; }
   #counter { font-size: 0.8rem; color: #888; padding-top: 6px; white-space: nowrap; }
   .bufferRow { display: flex; align-items: center; gap: 8px; }
-  .bufferRow label { font-size: 0.85rem; color: #aaa; }
-  .bufferRow input { width: 60px; padding: 5px 8px; background: #222; border: 1px solid #444; border-radius: 6px; color: #eee; font-size: 0.85rem; }
-  #help-bar { background: #0f0f23; padding: 6px 16px; font-size: 0.75rem; color: #666; border-top: 1px solid #222; }
-  #help-bar a { color: #4a9eff; text-decoration: none; }
+  .bufferRow label { font-size: 0.85rem; color: #555; }
+  .bufferRow input { width: 60px; padding: 5px 8px; background: #fff; border: 1px solid #ccc; border-radius: 6px; color: #222; font-size: 0.85rem; }
+  #help-bar { background: #fff; padding: 6px 16px; font-size: 0.75rem; color: #888; border-top: 1px solid #e0e0e0; }
+  #help-bar a { color: #1a6abf; text-decoration: none; }
   #help-bar a:hover { text-decoration: underline; }
-  #back-link { font-size: 0.8rem; color: #4a9eff; text-decoration: none; white-space: nowrap; }
+  #back-link { font-size: 0.8rem; color: #1a6abf; text-decoration: none; white-space: nowrap; }
   #back-link:hover { text-decoration: underline; }
 </style>
 </head>
@@ -76,7 +76,7 @@
 <script>
 const map = L.map('map').setView([50.5, 4.4], 8);
 
-L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
   attribution: '© OpenStreetMap © CartoDB',
   maxZoom: 19
 }).addTo(map);


### PR DESCRIPTION
## Summary

- Adds `POST /api/admin/prune-geo-filter` endpoint — dry-run by default, `?confirm=true` to permanently delete nodes outside the current geofilter polygon + buffer. Requires `X-API-Key` header.
- Adds **Prune nodes** section inside the GeoFilter customizer tab (write-access only, same `writeEnabled` gate as the PUT endpoint). **Preview** lists affected nodes; **Confirm delete** removes them.
- Adds `GetNodesForGeoPrune` and `DeleteNodesByPubkeys` DB helpers.
- Updates `docs/user-guide/geofilter.md` — documents the UI button as primary workflow, CLI script as alternative.

> **Depends on M3** (`feat/geofilter-m3-customizer`). This branch is based on that branch; M3 must merge before this PR can be merged cleanly.

## Test plan

- [ ] `cd cmd/server && go test ./...` — all pass
- [ ] Open Customizer → GeoFilter tab without `apiKey` configured — Prune section not visible
- [ ] With `apiKey` configured and polygon active — Prune section visible
- [ ] Click **Preview** — returns list of nodes outside polygon (no deletions)
- [ ] Click **Confirm delete** — nodes removed, list updates
- [ ] `POST /api/admin/prune-geo-filter` without `X-API-Key` → 401
- [ ] `POST /api/admin/prune-geo-filter` with no polygon configured → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)