### PR TITLE
fix: desktop node click updates URL hash, deep link opens split panel (#676)

### DIFF
--- a/public/nodes.js
+++ b/public/nodes.js
@@ -318,8 +318,8 @@
   function init(app, routeParam) {
     directNode = routeParam || null;
 
-    if (directNode) {
-      // Full-screen single node view
+    if (directNode && window.innerWidth <= 640) {
+      // Full-screen single node view (mobile only)
       app.innerHTML = `<div class="node-fullscreen">
         <div class="node-full-header">
           <button class="detail-back-btn node-back-btn" id="nodeBackBtn" aria-label="Back to nodes">←</button>
@@ -377,6 +377,7 @@
     }, 250));
 
     loadNodes();
+    if (directNode) selectNode(directNode);
     // Auto-refresh when ADVERT packets arrive via WebSocket (fixes #131)
     wsHandler = debouncedOnWS(function (msgs) {
       const advertMsgs = msgs.filter(isAdvertMessage);
@@ -979,6 +980,7 @@
           panel.classList.add('empty');
           panel.innerHTML = '<span>Select a node to view details</span>';
           selectedKey = null;
+          history.replaceState(null, '', '#/nodes');
           renderRows();
         }
       }
@@ -991,6 +993,7 @@
         panel.classList.add('empty');
         panel.innerHTML = '<span>Select a node to view details</span>';
         selectedKey = null;
+        history.replaceState(null, '', '#/nodes');
         renderRows();
       }
     });
@@ -1048,6 +1051,7 @@
       return;
     }
     selectedKey = pubkey;
+    history.replaceState(null, '', '#/nodes/' + encodeURIComponent(pubkey));
     renderRows();
     const panel = document.getElementById('nodesRight');
     panel.classList.remove('empty');

--- a/test-e2e-playwright.js
+++ b/test-e2e-playwright.js
@@ -1653,6 +1653,33 @@ async function run() {
     assert(url.includes('tab=room'), `URL should contain tab=room after click, got: ${url}`);
   });
 
+  // Test: clicking a node on desktop updates URL hash (#676)
+  await test('Desktop: clicking a node updates URL to #/nodes/{pubkey}', async () => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(BASE + '#/nodes', { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#nodesBody tr[data-key]', { timeout: 10000 });
+    const pubkey = await page.$eval('#nodesBody tr[data-key]', el => el.dataset.key);
+    await page.click('#nodesBody tr[data-key]');
+    await page.waitForTimeout(300);
+    const url = page.url();
+    assert(url.includes(encodeURIComponent(pubkey)), `URL should contain pubkey after click, got: ${url}`);
+    assert(!url.includes('node-fullscreen') || await page.$('#nodesRight:not(.empty)'), 'Split panel should be visible on desktop');
+  });
+
+  // Test: loading #/nodes/{pubkey} on desktop shows split panel (#676)
+  await test('Desktop: deep link #/nodes/{pubkey} opens split panel, not full-screen', async () => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(BASE + '#/nodes', { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#nodesBody tr[data-key]', { timeout: 10000 });
+    const pubkey = await page.$eval('#nodesBody tr[data-key]', el => el.dataset.key);
+    await page.goto(BASE + '#/nodes/' + encodeURIComponent(pubkey), { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(500);
+    const hasSplitPanel = await page.$('#nodesRight:not(.empty)');
+    const hasFullScreen = await page.$('.node-fullscreen');
+    assert(hasSplitPanel, 'Split panel should be open on desktop deep link');
+    assert(!hasFullScreen, 'Full-screen view should NOT appear on desktop deep link');
+  });
+
   // Test: packets timeWindow deep link
   await test('Packets timeWindow deep link restores dropdown', async () => {
     await page.goto(BASE + '#/packets?timeWindow=60', { waitUntil: 'domcontentloaded' });

--- a/test-e2e-playwright.js
+++ b/test-e2e-playwright.js
@@ -1470,6 +1470,8 @@ async function run() {
   // ─── Neighbor section tests ───────────────────────────────────────────────
 
   await test('Node detail: neighbors section exists with correct columns', async () => {
+    // Full-screen node view (with #node-neighbors) is mobile-only since #676 fix.
+    await page.setViewportSize({ width: 390, height: 844 });
     // Navigate to a node detail page (use the first node in the list)
     await page.goto(BASE + '/#/nodes');
     await page.waitForSelector('#nodesBody tr[data-key]', { timeout: 10000 });
@@ -1500,6 +1502,7 @@ async function run() {
       const text = await page.$eval('#fullNeighborsContent', el => el.textContent);
       assert(text.includes('No neighbor data') || text.includes('Could not load'), 'Should show empty or error state');
     }
+    await page.setViewportSize({ width: 1280, height: 800 });
   });
 
 


### PR DESCRIPTION
## Problem

Clicking a node on desktop opened the side panel but never updated the URL hash, making nodes non-shareable/bookmarkable on desktop. Loading `#/nodes/{pubkey}` directly on desktop also incorrectly showed the full-screen mobile view.

## Changes

- `selectNode()` on desktop: adds `history.replaceState(null, '', '#/nodes/' + pubkey)` so the URL updates on every click
- `init()`: full-screen path is now gated to `window.innerWidth <= 640` (mobile only); desktop with a `routeParam` falls through to the split panel and calls `selectNode()` to pre-select the node
- Deselect (Escape / close button): also calls `history.replaceState` back to `#/nodes`

## Test plan

- [x] Desktop: click a node → URL updates to `#/nodes/{pubkey}`, split panel opens
- [x] Desktop: copy URL, open in new tab → split panel opens with that node selected (not full-screen)
- [x] Desktop: press Escape → URL reverts to `#/nodes`
- [x] Mobile (≤640px): clicking a node still navigates to full-screen view

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)