### PR TITLE
fix: serialize filter params in URL hash for deep linking (#682)

### DIFF
--- a/public/packets.js
+++ b/public/packets.js
@@ -45,6 +45,10 @@
     var parts = [];
     if (timeWindowMin && timeWindowMin !== DEFAULT_TIME_WINDOW) parts.push('timeWindow=' + timeWindowMin);
     if (regionParam) parts.push('region=' + encodeURIComponent(regionParam));
+    if (filters.hash) parts.push('hash=' + encodeURIComponent(filters.hash));
+    if (filters.node) parts.push('node=' + encodeURIComponent(filters.node));
+    if (filters.observer) parts.push('observer=' + encodeURIComponent(filters.observer));
+    if (filters._filterExpr) parts.push('filter=' + encodeURIComponent(filters._filterExpr));
     return parts.length ? '?' + parts.join('&') : '';
   }
   window.buildPacketsQuery = buildPacketsQuery;
@@ -342,6 +346,14 @@
     }
     var _urlRegion = _initUrlParams.get('region');
     if (_urlRegion) _pendingUrlRegion = _urlRegion;
+    var _urlHash = _initUrlParams.get('hash');
+    if (_urlHash) filters.hash = _urlHash;
+    var _urlNode = _initUrlParams.get('node');
+    if (_urlNode) { filters.node = _urlNode; filters.nodeName = _urlNode.slice(0, 8); }
+    var _urlObserver = _initUrlParams.get('observer');
+    if (_urlObserver) filters.observer = _urlObserver;
+    var _urlFilterExpr = _initUrlParams.get('filter');
+    if (_urlFilterExpr) filters._filterExpr = _urlFilterExpr;
 
     app.innerHTML = `<div class="split-layout detail-collapsed">
       <div class="panel-left" id="pktLeft" aria-live="polite" aria-relevant="additions removals"></div>
@@ -797,6 +809,12 @@
       var pfError = document.getElementById('packetFilterError');
       var pfCount = document.getElementById('packetFilterCount');
       if (!pfInput || !window.PacketFilter) return;
+      // Restore Wireshark filter expression from URL
+      if (filters._filterExpr) {
+        pfInput.value = filters._filterExpr;
+        var _restored = PacketFilter.compile(filters._filterExpr);
+        if (!_restored.error) { pfInput.classList.add('filter-active'); filters._packetFilter = _restored.filter; }
+      }
       var pfTimer = null;
       pfInput.addEventListener('input', function() {
         clearTimeout(pfTimer);
@@ -807,6 +825,8 @@
             pfError.style.display = 'none';
             pfCount.style.display = 'none';
             filters._packetFilter = null;
+            filters._filterExpr = undefined;
+            updatePacketsUrl();
             renderTableRows();
             return;
           }
@@ -818,12 +838,16 @@
             pfError.style.display = 'block';
             pfCount.style.display = 'none';
             filters._packetFilter = null;
+            filters._filterExpr = undefined;
+            updatePacketsUrl();
             renderTableRows();
           } else {
             pfInput.classList.remove('filter-error');
             pfInput.classList.add('filter-active');
             pfError.style.display = 'none';
             filters._packetFilter = compiled.filter;
+            filters._filterExpr = expr;
+            updatePacketsUrl();
             renderTableRows();
           }
         }, 300);
@@ -868,6 +892,7 @@
       if (filters.observer) localStorage.setItem('meshcore-observer-filter', filters.observer); else localStorage.removeItem('meshcore-observer-filter');
       buildObserverMenu();
       updateObsTrigger();
+      updatePacketsUrl();
       renderTableRows();
     });
 
@@ -930,7 +955,7 @@
 
     // Filter event listeners
     document.getElementById('fHash').value = filters.hash || '';
-    document.getElementById('fHash').addEventListener('input', debounce((e) => { filters.hash = e.target.value || undefined; loadPackets(); }, 300));
+    document.getElementById('fHash').addEventListener('input', debounce((e) => { filters.hash = e.target.value || undefined; updatePacketsUrl(); loadPackets(); }, 300));
 
     // Time window dropdown — restore from localStorage and bind change
     const fTimeWindow = document.getElementById('fTimeWindow');
@@ -1065,7 +1090,7 @@
       if (!q) {
         fNodeDrop.classList.add('hidden');
         fNode.setAttribute('aria-expanded', 'false');
-        if (filters.node) { filters.node = undefined; filters.nodeName = undefined; loadPackets(); }
+        if (filters.node) { filters.node = undefined; filters.nodeName = undefined; updatePacketsUrl(); loadPackets(); }
         return;
       }
       try {
@@ -1094,6 +1119,7 @@
       fNode.setAttribute('aria-expanded', 'false');
       fNode.setAttribute('aria-activedescendant', '');
       nodeActiveIdx = -1;
+      updatePacketsUrl();
       loadPackets();
     }
 

--- a/test-e2e-playwright.js
+++ b/test-e2e-playwright.js
@@ -1687,15 +1687,15 @@ async function run() {
   await test('Packets filter expression updates URL and restores on reload', async () => {
     await page.goto(BASE + '#/packets', { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('#packetFilterInput', { timeout: 8000 });
-    await page.fill('#packetFilterInput', 'type=ADVERT');
+    await page.fill('#packetFilterInput', 'type == ADVERT');
     await page.waitForTimeout(500);
     const url = page.url();
-    assert(url.includes('filter=') && url.includes('ADVERT'), `URL should contain filter=type%3DADVERT, got: ${url}`);
+    assert(url.includes('filter=') && url.includes('ADVERT'), `URL should contain filter=type%3D%3DADVERT, got: ${url}`);
     // Reload and check expression restored
     await page.goto(url, { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('#packetFilterInput', { timeout: 8000 });
     const val = await page.$eval('#packetFilterInput', el => el.value);
-    assert(val === 'type=ADVERT', `packetFilterInput should be restored, got: ${val}`);
+    assert(val === 'type == ADVERT', `packetFilterInput should be restored, got: ${val}`);
   });
 
   // Test: timeWindow change updates URL

--- a/test-e2e-playwright.js
+++ b/test-e2e-playwright.js
@@ -1663,6 +1663,36 @@ async function run() {
     assert(url.includes('timeWindow=60'), `URL should still contain timeWindow=60, got: ${url}`);
   });
 
+  // Test: hash filter updates URL and is restored (#682)
+  await test('Packets hash filter updates URL and restores on reload', async () => {
+    await page.goto(BASE + '#/packets', { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#fHash', { timeout: 8000 });
+    await page.fill('#fHash', 'abc123');
+    await page.waitForTimeout(500);
+    const url = page.url();
+    assert(url.includes('hash=abc123'), `URL should contain hash=abc123, got: ${url}`);
+    // Reload and check input restored
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#fHash', { timeout: 8000 });
+    const val = await page.$eval('#fHash', el => el.value);
+    assert(val === 'abc123', `fHash should be restored to abc123, got: ${val}`);
+  });
+
+  // Test: Wireshark filter expression updates URL and is restored (#682)
+  await test('Packets filter expression updates URL and restores on reload', async () => {
+    await page.goto(BASE + '#/packets', { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#packetFilterInput', { timeout: 8000 });
+    await page.fill('#packetFilterInput', 'type=ADVERT');
+    await page.waitForTimeout(500);
+    const url = page.url();
+    assert(url.includes('filter=') && url.includes('ADVERT'), `URL should contain filter=type%3DADVERT, got: ${url}`);
+    // Reload and check expression restored
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('#packetFilterInput', { timeout: 8000 });
+    const val = await page.$eval('#packetFilterInput', el => el.value);
+    assert(val === 'type=ADVERT', `packetFilterInput should be restored, got: ${val}`);
+  });
+
   // Test: timeWindow change updates URL
   await test('Packets timeWindow change updates URL', async () => {
     await page.goto(BASE + '#/packets', { waitUntil: 'domcontentloaded' });

--- a/test-e2e-playwright.js
+++ b/test-e2e-playwright.js
@@ -398,8 +398,9 @@ async function run() {
       }
     }, { timeout: 10000 });
 
-    // Full reload on the packets page — scripts re-execute, IIFE reads localStorage
-    await page.reload({ waitUntil: 'load' });
+    // Navigate to clean #/packets URL — avoids leftover filter params from a previous
+    // test being re-read from the URL and overriding the localStorage value we just set (#682).
+    await page.goto(`${BASE}/#/packets`, { waitUntil: 'load' });
     await page.waitForSelector('#fTimeWindow', { timeout: 10000 });
     const timeWindowValue = await page.$eval('#fTimeWindow', (el) => el.value);
     assert(timeWindowValue === '60', `Expected time window dropdown to restore 60, got ${timeWindowValue}`);

--- a/test-e2e-playwright.js
+++ b/test-e2e-playwright.js
@@ -398,8 +398,12 @@ async function run() {
       }
     }, { timeout: 10000 });
 
-    // Navigate to clean #/packets URL — avoids leftover filter params from a previous
-    // test being re-read from the URL and overriding the localStorage value we just set (#682).
+    // Force a full page reload to reset module-level state (savedTimeWindowMin is
+    // read from localStorage once at IIFE time). Navigating from /#/packets to /#/packets
+    // is a hash-only change — no reload, so the IIFE never re-reads localStorage.
+    // Going to / first forces a fresh page load, then the hash change to /#/packets
+    // calls init() with the freshly-read savedTimeWindowMin = 60.
+    await page.goto(`${BASE}/`, { waitUntil: 'load' });
     await page.goto(`${BASE}/#/packets`, { waitUntil: 'load' });
     await page.waitForSelector('#fTimeWindow', { timeout: 10000 });
     const timeWindowValue = await page.$eval('#fTimeWindow', (el) => el.value);


### PR DESCRIPTION
## Problem

Applying packet filters (hash, node, observer, Wireshark expression) did not update the URL hash, so filtered views could not be shared or bookmarked.

## Changes

**`buildPacketsQuery()`** — extended to include:
- `hash=` from `filters.hash`
- `node=` from `filters.node`  
- `observer=` from `filters.observer`
- `filter=` from `filters._filterExpr` (Wireshark expression string)

**`updatePacketsUrl()`** — now called on every filter change:
- hash input (debounced)
- observer multi-select change
- node autocomplete select and clear
- Wireshark filter input (on valid expression or clear)

**URL restore on load** — `getHashParams()` now reads `hash`, `node`, `observer`, `filter` and restores them into `filters` before the DOM is built. Input fields pick up values from `filters` as before. Wireshark expression is also recompiled and `filter-active` class applied.

## Test plan

- [ ] Type in hash filter → URL updates with `&hash=...`
- [ ] Copy URL, open in new tab → hash filter is pre-filled
- [ ] Select an observer → URL updates with `&observer=...`
- [ ] Select a node filter → URL updates with `&node=...`
- [ ] Type `type=ADVERT` in Wireshark filter → URL updates with `&filter=type%3DADVERT`
- [ ] Load that URL → filter expression restored and active

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)