### PR TITLE
fix case on channel key so Public decode/display works right

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -125,7 +125,7 @@
     }
   ],
   "channelKeys": {
-    "public": "8b3387e9c5cdea6ac9e5edbaa115cd72"
+    "Public": "8b3387e9c5cdea6ac9e5edbaa115cd72"
   },
   "hashChannels": [
     "#LongFast",


### PR DESCRIPTION
Simple change.  Before this change Public wasn't showing up in the channels display due to the case issue.