### PR TITLE
fix: capitalize first letter of known channel display names

### DIFF
--- a/cmd/ingestor/.gitignore
+++ b/cmd/ingestor/.gitignore
@@ -1,1 +1,1 @@
-cmd/ingestor/ingestor
+ingestor

--- a/cmd/ingestor/.gitignore
+++ b/cmd/ingestor/.gitignore
@@ -1,0 +1,1 @@
+cmd/ingestor/ingestor

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -416,11 +416,15 @@ func applySchema(db *sql.DB) error {
 	if row.Scan(&migDone) != nil {
 		log.Println("[migration] Normalizing known channel_hash values...")
 		res, err := db.Exec(`UPDATE transmissions SET channel_hash = 'Public' WHERE channel_hash = 'public' AND payload_type = 5`)
-		if err == nil {
-			n, _ := res.RowsAffected()
-			log.Printf("[migration] Normalized %d channel_hash rows from 'public' to 'Public'", n)
+		if err != nil {
+			log.Printf("[migration] ERROR: failed to normalize channel_hash: %v", err)
+			return fmt.Errorf("migration channel_hash_casing_v1 UPDATE failed: %w", err)
 		}
-		db.Exec(`INSERT INTO _migrations (name) VALUES ('channel_hash_casing_v1')`)
+		n, _ := res.RowsAffected()
+		log.Printf("[migration] Normalized %d channel_hash rows from 'public' to 'Public'", n)
+		if _, err := db.Exec(`INSERT OR IGNORE INTO _migrations (name) VALUES ('channel_hash_casing_v1')`); err != nil {
+			log.Printf("[migration] WARNING: failed to record migration: %v", err)
+		}
 		log.Println("[migration] channel_hash casing normalization complete")
 	}
 

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -408,6 +408,22 @@ func applySchema(db *sql.DB) error {
 		log.Println("[migration] dropped_packets table created")
 	}
 
+	// Migration: normalize known channel_hash values for existing rows.
+	// Before this PR, config key "public" was stored as channel_hash="public".
+	// After this PR, new rows use channel_hash="Public". Without backfill,
+	// channel grouping queries split into two buckets across the upgrade boundary.
+	row = db.QueryRow("SELECT 1 FROM _migrations WHERE name = 'channel_hash_casing_v1'")
+	if row.Scan(&migDone) != nil {
+		log.Println("[migration] Normalizing known channel_hash values...")
+		res, err := db.Exec(`UPDATE transmissions SET channel_hash = 'Public' WHERE channel_hash = 'public' AND payload_type = 5`)
+		if err == nil {
+			n, _ := res.RowsAffected()
+			log.Printf("[migration] Normalized %d channel_hash rows from 'public' to 'Public'", n)
+		}
+		db.Exec(`INSERT INTO _migrations (name) VALUES ('channel_hash_casing_v1')`)
+		log.Println("[migration] channel_hash casing normalization complete")
+	}
+
 	return nil
 }
 

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -564,11 +564,15 @@ func applySchema(db *sql.DB) error {
 	if row.Scan(&migDone) != nil {
 		log.Println("[migration] Normalizing known channel_hash values...")
 		res, err := db.Exec(`UPDATE transmissions SET channel_hash = 'Public' WHERE channel_hash = 'public' AND payload_type = 5`)
-		if err == nil {
-			n, _ := res.RowsAffected()
-			log.Printf("[migration] Normalized %d channel_hash rows from 'public' to 'Public'", n)
+		if err != nil {
+			log.Printf("[migration] ERROR: failed to normalize channel_hash: %v", err)
+			return fmt.Errorf("migration channel_hash_casing_v1 UPDATE failed: %w", err)
 		}
-		db.Exec(`INSERT INTO _migrations (name) VALUES ('channel_hash_casing_v1')`)
+		n, _ := res.RowsAffected()
+		log.Printf("[migration] Normalized %d channel_hash rows from 'public' to 'Public'", n)
+		if _, err := db.Exec(`INSERT OR IGNORE INTO _migrations (name) VALUES ('channel_hash_casing_v1')`); err != nil {
+			log.Printf("[migration] WARNING: failed to record migration: %v", err)
+		}
 		log.Println("[migration] channel_hash casing normalization complete")
 	}
 

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -556,6 +556,22 @@ func applySchema(db *sql.DB) error {
 	// this column as hasDefaultScope; keeping a single canonical Apply
 	// path closes the startup race that #1321 documented.
 
+	// Migration: normalize known channel_hash values for existing rows.
+	// Before this PR, config key "public" was stored as channel_hash="public".
+	// After this PR, new rows use channel_hash="Public". Without backfill,
+	// channel grouping queries split into two buckets across the upgrade boundary.
+	row = db.QueryRow("SELECT 1 FROM _migrations WHERE name = 'channel_hash_casing_v1'")
+	if row.Scan(&migDone) != nil {
+		log.Println("[migration] Normalizing known channel_hash values...")
+		res, err := db.Exec(`UPDATE transmissions SET channel_hash = 'Public' WHERE channel_hash = 'public' AND payload_type = 5`)
+		if err == nil {
+			n, _ := res.RowsAffected()
+			log.Printf("[migration] Normalized %d channel_hash rows from 'public' to 'Public'", n)
+		}
+		db.Exec(`INSERT INTO _migrations (name) VALUES ('channel_hash_casing_v1')`)
+		log.Println("[migration] channel_hash casing normalization complete")
+	}
+
 	return nil
 }
 

--- a/cmd/ingestor/decoder.go
+++ b/cmd/ingestor/decoder.go
@@ -423,6 +423,22 @@ func decryptChannelMessage(ciphertextHex, macHex, channelKeyHex string) (*channe
 	return result, nil
 }
 
+// knownChannelCasing maps known channel keys to their canonical display names.
+// Only well-known channels are normalized — custom/user channels are left as-is.
+var knownChannelCasing = map[string]string{
+	"public": "Public",
+}
+
+// normalizeChannelName fixes casing for well-known channel names.
+// Only normalizes names that appear in knownChannelCasing (e.g. "public" → "Public").
+// Custom channel names are left untouched since we can't know the intended casing.
+func normalizeChannelName(name string) string {
+	if corrected, ok := knownChannelCasing[strings.ToLower(name)]; ok {
+		return corrected
+	}
+	return name
+}
+
 func decodeGrpTxt(buf []byte, channelKeys map[string]string) Payload {
 	if len(buf) < 3 {
 		return Payload{Type: "GRP_TXT", Error: "too short", RawHex: hex.EncodeToString(buf)}
@@ -447,7 +463,7 @@ func decodeGrpTxt(buf []byte, channelKeys map[string]string) Payload {
 			}
 			return Payload{
 				Type:             "CHAN",
-				Channel:          name,
+				Channel:          normalizeChannelName(name),
 				ChannelHash:      channelHash,
 				ChannelHashHex:   channelHashHex,
 				DecryptionStatus: "decrypted",

--- a/cmd/ingestor/decoder.go
+++ b/cmd/ingestor/decoder.go
@@ -493,6 +493,22 @@ func decryptChannelMessage(ciphertextHex, macHex, channelKeyHex string) (*channe
 	return result, nil
 }
 
+// knownChannelCasing maps known channel keys to their canonical display names.
+// Only well-known channels are normalized — custom/user channels are left as-is.
+var knownChannelCasing = map[string]string{
+	"public": "Public",
+}
+
+// normalizeChannelName fixes casing for well-known channel names.
+// Only normalizes names that appear in knownChannelCasing (e.g. "public" → "Public").
+// Custom channel names are left untouched since we can't know the intended casing.
+func normalizeChannelName(name string) string {
+	if corrected, ok := knownChannelCasing[strings.ToLower(name)]; ok {
+		return corrected
+	}
+	return name
+}
+
 func decodeGrpTxt(buf []byte, channelKeys map[string]string) Payload {
 	if len(buf) < 3 {
 		return Payload{Type: "GRP_TXT", Error: "too short", RawHex: hex.EncodeToString(buf)}
@@ -517,7 +533,7 @@ func decodeGrpTxt(buf []byte, channelKeys map[string]string) Payload {
 			}
 			return Payload{
 				Type:             "CHAN",
-				Channel:          name,
+				Channel:          normalizeChannelName(name),
 				ChannelHash:      channelHash,
 				ChannelHashHex:   channelHashHex,
 				DecryptionStatus: "decrypted",

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -810,9 +810,8 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 		}
 		// Detect config collision: if both "public" and "Public" are present,
 		// the normalized key collides. Log a warning and let the last one win.
-		if existing, dupe := keys[normalized]; dupe {
+		if _, dupe := keys[normalized]; dupe {
 			log.Printf("[channels] WARNING: duplicate channel key %q — config has both %q and another key normalizing to %q, keeping last value", normalized, k, normalized)
-			_ = existing
 		}
 		keys[normalized] = v
 	}

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -804,7 +804,11 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 
 	// 3. Explicit config keys (highest priority — overrides rainbow + derived)
 	for k, v := range cfg.ChannelKeys {
-		keys[k] = v
+		normalized := normalizeChannelName(k)
+		if normalized != k {
+			log.Printf("[channels] Normalizing known channel key %q → %q for display", k, normalized)
+		}
+		keys[normalized] = v
 	}
 
 	return keys

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -808,6 +808,12 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 		if normalized != k {
 			log.Printf("[channels] Normalizing known channel key %q → %q for display", k, normalized)
 		}
+		// Detect config collision: if both "public" and "Public" are present,
+		// the normalized key collides. Log a warning and let the last one win.
+		if existing, dupe := keys[normalized]; dupe {
+			log.Printf("[channels] WARNING: duplicate channel key %q — config has both %q and another key normalizing to %q, keeping last value", normalized, k, normalized)
+			_ = existing
+		}
 		keys[normalized] = v
 	}
 

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -1163,9 +1163,8 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 		}
 		// Detect config collision: if both "public" and "Public" are present,
 		// the normalized key collides. Log a warning and let the last one win.
-		if existing, dupe := keys[normalized]; dupe {
+		if _, dupe := keys[normalized]; dupe {
 			log.Printf("[channels] WARNING: duplicate channel key %q — config has both %q and another key normalizing to %q, keeping last value", normalized, k, normalized)
-			_ = existing
 		}
 		keys[normalized] = v
 	}

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -1162,11 +1162,20 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 			log.Printf("[channels] Normalizing known channel key %q → %q for display", k, normalized)
 		}
 		// Detect config collision: if both "public" and "Public" are present,
-		// the normalized key collides. Log a warning and let the last one win.
+		// the normalized key collides. Resolve deterministically: prefer the
+		// canonical (already-normalized) form over the lowercase variant.
 		if _, dupe := keys[normalized]; dupe {
-			log.Printf("[channels] WARNING: duplicate channel key %q — config has both %q and another key normalizing to %q, keeping last value", normalized, k, normalized)
+			// If the incoming key IS the canonical form, it wins (overwrite).
+			// If the incoming key is a non-canonical form (e.g., "public"), keep existing.
+			if k == normalized {
+				log.Printf("[channels] Resolving duplicate %q: canonical form wins over non-canonical", normalized)
+				keys[normalized] = v
+			} else {
+				log.Printf("[channels] WARNING: duplicate channel key %q — config has %q normalizing to %q, keeping canonical value", normalized, k, normalized)
+			}
+		} else {
+			keys[normalized] = v
 		}
-		keys[normalized] = v
 	}
 
 	return keys

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -1161,6 +1161,12 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 		if normalized != k {
 			log.Printf("[channels] Normalizing known channel key %q → %q for display", k, normalized)
 		}
+		// Detect config collision: if both "public" and "Public" are present,
+		// the normalized key collides. Log a warning and let the last one win.
+		if existing, dupe := keys[normalized]; dupe {
+			log.Printf("[channels] WARNING: duplicate channel key %q — config has both %q and another key normalizing to %q, keeping last value", normalized, k, normalized)
+			_ = existing
+		}
 		keys[normalized] = v
 	}
 

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -1157,7 +1157,11 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 
 	// 3. Explicit config keys (highest priority — overrides rainbow + derived)
 	for k, v := range cfg.ChannelKeys {
-		keys[k] = v
+		normalized := normalizeChannelName(k)
+		if normalized != k {
+			log.Printf("[channels] Normalizing known channel key %q → %q for display", k, normalized)
+		}
+		keys[normalized] = v
 	}
 
 	return keys

--- a/cmd/ingestor/normalize_channel_test.go
+++ b/cmd/ingestor/normalize_channel_test.go
@@ -69,3 +69,29 @@ func TestLoadChannelKeys_LeavesCustomNamesUntouched(t *testing.T) {
 		t.Error("Custom channel names should NOT be auto-capitalized")
 	}
 }
+
+func TestLoadChannelKeys_DuplicateCasingLogsWarning(t *testing.T) {
+	// Verify that config with both "public" and "Public" logs a warning
+	// and the last one wins (Go map iteration order is nondeterministic)
+	cfg := &Config{
+		ChannelKeys: map[string]string{
+			"public": "8b3387e9c5cdea6ac9e5edbaa115cd72",
+			"Public": "differentkey1234567",
+		},
+	}
+
+	keys := loadChannelKeys(cfg, "/dev/null")
+
+	// After normalization, only one key should exist: "Public"
+	// The value is nondeterministic since Go map iteration order varies
+	if _, ok := keys["public"]; ok {
+		t.Error("Expected 'public' to be normalized away")
+	}
+	if _, ok := keys["Public"]; !ok {
+		t.Error("Expected 'Public' key to exist")
+	}
+	// Exactly one entry for the normalized key
+	if len(keys) != 1 {
+		t.Errorf("Expected exactly 1 key, got %d", len(keys))
+	}
+}

--- a/cmd/ingestor/normalize_channel_test.go
+++ b/cmd/ingestor/normalize_channel_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestNormalizeChannelName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Known channel: "public" should be normalized to "Public"
+		{"public", "Public"},
+		{"Public", "Public"},
+		{"PUBLIC", "Public"},
+		// Hashtag channels should be left untouched
+		{"#LongFast", "#LongFast"},
+		{"#wardrive", "#wardrive"},
+		// Custom/unknown channels should be left untouched
+		{"myChannel", "myChannel"},
+		{"testchannel", "testchannel"},
+		// Empty string
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := normalizeChannelName(tt.input)
+		if got != tt.expected {
+			t.Errorf("normalizeChannelName(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestLoadChannelKeys_NormalizesKnownDisplayNames(t *testing.T) {
+	// Verify that known channel keys with wrong casing get normalized
+	cfg := &Config{
+		ChannelKeys: map[string]string{
+			"public": "8b3387e9c5cdea6ac9e5edbaa115cd72",
+		},
+	}
+
+	keys := loadChannelKeys(cfg, "/dev/null")
+
+	// Should have "Public" (normalized) not "public" (raw)
+	if _, ok := keys["public"]; ok {
+		t.Error("Expected 'public' to be normalized to 'Public'")
+	}
+	if _, ok := keys["Public"]; !ok {
+		t.Error("Expected 'Public' key to exist in loaded channel keys")
+	}
+}
+
+func TestLoadChannelKeys_LeavesCustomNamesUntouched(t *testing.T) {
+	// Verify that custom channel names are NOT normalized
+	cfg := &Config{
+		ChannelKeys: map[string]string{
+			"myCustomChannel": "deadbeef12345678",
+		},
+	}
+
+	keys := loadChannelKeys(cfg, "/dev/null")
+
+	// Should keep "myCustomChannel" as-is
+	if _, ok := keys["myCustomChannel"]; !ok {
+		t.Error("Expected 'myCustomChannel' to be left untouched")
+	}
+	// Should NOT have "MyCustomChannel"
+	if _, ok := keys["MyCustomChannel"]; ok {
+		t.Error("Custom channel names should NOT be auto-capitalized")
+	}
+}

--- a/cmd/ingestor/normalize_channel_test.go
+++ b/cmd/ingestor/normalize_channel_test.go
@@ -71,8 +71,8 @@ func TestLoadChannelKeys_LeavesCustomNamesUntouched(t *testing.T) {
 }
 
 func TestLoadChannelKeys_DuplicateCasingLogsWarning(t *testing.T) {
-	// Verify that config with both "public" and "Public" logs a warning
-	// and the last one wins (Go map iteration order is nondeterministic)
+	// Verify that config with both "public" and "Public" resolves deterministically:
+	// the canonical (already-normalized) form should win.
 	cfg := &Config{
 		ChannelKeys: map[string]string{
 			"public": "8b3387e9c5cdea6ac9e5edbaa115cd72",
@@ -83,15 +83,15 @@ func TestLoadChannelKeys_DuplicateCasingLogsWarning(t *testing.T) {
 	keys := loadChannelKeys(cfg, "/dev/null")
 
 	// After normalization, only one key should exist: "Public"
-	// The value is nondeterministic since Go map iteration order varies
+	// The canonical form ("Public") should win over the lowercase form ("public")
 	if _, ok := keys["public"]; ok {
 		t.Error("Expected 'public' to be normalized away")
 	}
 	if _, ok := keys["Public"]; !ok {
 		t.Error("Expected 'Public' key to exist")
 	}
-	// Exactly one entry for the normalized key
-	if len(keys) != 1 {
-		t.Errorf("Expected exactly 1 key, got %d", len(keys))
+	// Assert the canonical form's value won, not just any value
+	if keys["Public"] != "differentkey1234567" {
+		t.Errorf("Expected canonical 'Public' value to win, got %q", keys["Public"])
 	}
 }


### PR DESCRIPTION
## Problem

PR #761 fixed the example config to use `"Public"` instead of `"public"`, but this only helps new deployments. Existing deployments that copied the old lowercase `"public"` key still see "public" (lowercase) as the channel display name in the UI.

The root cause: `channelKeys` map keys are used directly as display names in `decodeGrpTxt()` (see `decoder.go:439` — `Channel: name`). If the config has `"public"`, the channel shows as "public" forever.

## Fix

**Known-channel normalization only** — we only fix casing for well-known channel names that have a canonical form. Custom/user-defined channel names are left untouched since we cannot know the intended casing.

1. **`knownChannelCasing` lookup** (`decoder.go`): A map of known lowercase channel keys to their canonical display names. Currently only `"public" → "Public"`. Easy to extend if more channels need fixing.

2. **`normalizeChannelName()`** (`decoder.go`): Only corrects entries that appear in `knownChannelCasing`. Custom channels like `myChannel` or `testchannel` are left completely untouched.

3. **Config load time** (`loadChannelKeys` in `main.go`): When loading explicit `channelKeys` from config, known lowercase keys like `"public"` are normalized to `"Public"` with a log message: `[channels] Normalizing known channel key "public" → "Public" for display`

4. **Decoder level**: Applied where `Channel: name` was previously set raw.

This ensures existing deployments with `"public"` in their config display "Public" properly, while respecting custom channel names that may intentionally be lowercase.

## Tests

- `TestNormalizeChannelName` — verifies known names are fixed, custom names untouched, hashtag names unchanged
- `TestLoadChannelKeys_NormalizesKnownDisplayNames` — verifies `"public"` → `"Public"` in config loading
- `TestLoadChannelKeys_LeavesCustomNamesUntouched` — verifies custom names are NOT modified

Related: #761