### PR TITLE
fix: bypass IATA filter for status messages, fill SNR on duplicate obs (#694)

### DIFF
--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -433,8 +433,12 @@ func (s *Store) prepareStatements() error {
 	}
 
 	s.stmtInsertObservation, err = s.db.Prepare(`
-		INSERT OR IGNORE INTO observations (transmission_id, observer_idx, direction, snr, rssi, score, path_json, timestamp)
+		INSERT INTO observations (transmission_id, observer_idx, direction, snr, rssi, score, path_json, timestamp)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(transmission_id, observer_idx, COALESCE(path_json, '')) DO UPDATE SET
+			snr   = COALESCE(excluded.snr,   snr),
+			rssi  = COALESCE(excluded.rssi,  rssi),
+			score = COALESCE(excluded.score, score)
 	`)
 	if err != nil {
 		return err

--- a/cmd/ingestor/db_test.go
+++ b/cmd/ingestor/db_test.go
@@ -1882,3 +1882,89 @@ func TestExtractObserverMetaNewFields(t *testing.T) {
 		t.Errorf("RecvErrors = %v, want 3", meta.RecvErrors)
 	}
 }
+
+// TestInsertObservationSNRFillIn verifies that when the same observation is
+// received twice — first without SNR, then with SNR — the SNR is filled in
+// rather than silently discarded. The unique dedup index is
+// (transmission_id, observer_idx, COALESCE(path_json, '')); observer_idx must
+// be non-NULL for the conflict to fire (SQLite treats NULL != NULL).
+func TestInsertObservationSNRFillIn(t *testing.T) {
+	s, err := OpenStore(tempDBPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Register the observer so observer_idx is non-NULL (required for dedup).
+	if err := s.UpsertObserver("pymc-obs1", "PyMC Observer", "SJC", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// First arrival: same observer, no SNR/RSSI (e.g. broker replay without RF fields).
+	data1 := &PacketData{
+		RawHex:     "0A00D69FD7A5A7475DB07337749AE61FA53A4788E976",
+		Timestamp:  "2026-04-20T00:00:00Z",
+		Hash:       "snrfillin0001hash",
+		RouteType:  1,
+		ObserverID: "pymc-obs1",
+		SNR:        nil,
+		RSSI:       nil,
+	}
+	if _, err := s.InsertTransmission(data1); err != nil {
+		t.Fatal(err)
+	}
+
+	var snr1, rssi1 *float64
+	s.db.QueryRow("SELECT snr, rssi FROM observations LIMIT 1").Scan(&snr1, &rssi1)
+	if snr1 != nil || rssi1 != nil {
+		t.Fatalf("precondition: first insert should have nil SNR/RSSI, got snr=%v rssi=%v", snr1, rssi1)
+	}
+
+	// Second arrival: same packet, same observer, now WITH SNR/RSSI.
+	snr := 10.5
+	rssi := -88.0
+	data2 := &PacketData{
+		RawHex:     data1.RawHex,
+		Timestamp:  data1.Timestamp,
+		Hash:       data1.Hash,
+		RouteType:  data1.RouteType,
+		ObserverID: "pymc-obs1",
+		SNR:        &snr,
+		RSSI:       &rssi,
+	}
+	if _, err := s.InsertTransmission(data2); err != nil {
+		t.Fatal(err)
+	}
+
+	var snr2, rssi2 *float64
+	s.db.QueryRow("SELECT snr, rssi FROM observations LIMIT 1").Scan(&snr2, &rssi2)
+	if snr2 == nil || *snr2 != snr {
+		t.Errorf("SNR not filled in by second arrival: got %v, want %v", snr2, snr)
+	}
+	if rssi2 == nil || *rssi2 != rssi {
+		t.Errorf("RSSI not filled in by second arrival: got %v, want %v", rssi2, rssi)
+	}
+
+	// Third arrival: same packet again, SNR absent — must NOT overwrite existing SNR.
+	data3 := &PacketData{
+		RawHex:     data1.RawHex,
+		Timestamp:  data1.Timestamp,
+		Hash:       data1.Hash,
+		RouteType:  data1.RouteType,
+		ObserverID: "pymc-obs1",
+		SNR:        nil,
+		RSSI:       nil,
+	}
+	if _, err := s.InsertTransmission(data3); err != nil {
+		t.Fatal(err)
+	}
+
+	var snr3, rssi3 *float64
+	s.db.QueryRow("SELECT snr, rssi FROM observations LIMIT 1").Scan(&snr3, &rssi3)
+	if snr3 == nil || *snr3 != snr {
+		t.Errorf("SNR overwritten by null arrival: got %v, want %v", snr3, snr)
+	}
+	if rssi3 == nil || *rssi3 != rssi {
+		t.Errorf("RSSI overwritten by null arrival: got %v, want %v", rssi3, rssi)
+	}
+}

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -207,21 +207,6 @@ func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, 
 	topic := m.Topic()
 	parts := strings.Split(topic, "/")
 
-	// IATA filter
-	if len(source.IATAFilter) > 0 && len(parts) > 1 {
-		region := parts[1]
-		matched := false
-		for _, f := range source.IATAFilter {
-			if f == region {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return
-		}
-	}
-
 	var msg map[string]interface{}
 	if err := json.Unmarshal(m.Payload(), &msg); err != nil {
 		return
@@ -233,6 +218,9 @@ func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, 
 	}
 
 	// Status topic: meshcore/<region>/<observer_id>/status
+	// IATA filter does NOT apply here — observer metadata (noise_floor, battery, etc.)
+	// is region-independent and should be accepted from all observers regardless of
+	// which IATA regions are configured for packet ingestion.
 	if len(parts) >= 4 && parts[3] == "status" {
 		observerID := parts[2]
 		name, _ := msg["origin"].(string)
@@ -259,6 +247,21 @@ func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, 
 		}
 		log.Printf("MQTT [%s] status: %s (%s)", tag, firstNonEmpty(name, observerID), iata)
 		return
+	}
+
+	// IATA filter applies to packet messages only — not status messages above.
+	if len(source.IATAFilter) > 0 && len(parts) > 1 {
+		region := parts[1]
+		matched := false
+		for _, f := range source.IATAFilter {
+			if f == region {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return
+		}
 	}
 
 	// Format 1: Raw packet (meshcoretomqtt / Cisien format)

--- a/cmd/ingestor/main_test.go
+++ b/cmd/ingestor/main_test.go
@@ -739,3 +739,44 @@ func TestToFloat64WithUnits(t *testing.T) {
 		}
 	}
 }
+
+// TestIATAFilterDoesNotDropStatusMessages verifies that status messages from
+// out-of-region observers are still processed (noise_floor, battery, etc.)
+// even when an IATA filter is configured for packet data.
+func TestIATAFilterDoesNotDropStatusMessages(t *testing.T) {
+	store := newTestStore(t)
+	source := MQTTSource{Name: "test", IATAFilter: []string{"SJC"}}
+
+	// BFL observer sends a status message with noise_floor — outside the IATA filter.
+	msg := &mockMessage{
+		topic:   "meshcore/BFL/bfl-obs1/status",
+		payload: []byte(`{"origin":"BFLObserver","stats":{"noise_floor":-105.0}}`),
+	}
+	handleMessage(store, "test", source, msg, nil, &Config{})
+
+	var name string
+	var noiseFloor *float64
+	err := store.db.QueryRow("SELECT name, noise_floor FROM observers WHERE id = 'bfl-obs1'").Scan(&name, &noiseFloor)
+	if err != nil {
+		t.Fatalf("observer not found after status from out-of-region observer: %v", err)
+	}
+	if name != "BFLObserver" {
+		t.Errorf("name=%q, want BFLObserver", name)
+	}
+	if noiseFloor == nil || *noiseFloor != -105.0 {
+		t.Errorf("noise_floor=%v, want -105.0 — status message was dropped by IATA filter when it should not be", noiseFloor)
+	}
+
+	// Verify that a packet from BFL is still filtered.
+	rawHex := "0A00D69FD7A5A7475DB07337749AE61FA53A4788E976"
+	pktMsg := &mockMessage{
+		topic:   "meshcore/BFL/bfl-obs1/packets",
+		payload: []byte(`{"raw":"` + rawHex + `"}`),
+	}
+	handleMessage(store, "test", source, pktMsg, nil, &Config{})
+	var count int
+	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
+	if count != 0 {
+		t.Error("packet from out-of-region BFL should still be filtered by IATA")
+	}
+}


### PR DESCRIPTION
## Problems

Two independent ingestor bugs identified in #694:

### 1. IATA filter drops status messages from out-of-region observers

The IATA filter ran at the top of `handleMessage()` before any message-type discrimination. Status messages carrying observer metadata (`noise_floor`, battery, airtime) from observers outside the configured IATA regions were silently discarded before `UpsertObserver()` and `InsertMetrics()` ran.

**Impact:** Observers running `meshcoretomqtt/1.0.8.0` in BFL and LAX — the only client versions that include `noise_floor` in status messages — had their health data dropped entirely on prod instances filtering to SJC.

**Fix:** Moved the IATA filter to the packet path only (after the `parts[3] == "status"` branch). Status messages now always populate observer health data regardless of configured region filter.

### 2. `INSERT OR IGNORE` discards SNR/RSSI on late arrival

When the same `(transmission_id, observer_idx, path_json)` observation arrived twice — first without RF fields, then with — `INSERT OR IGNORE` silently discarded the SNR/RSSI from the second arrival.

**Fix:** Changed to `ON CONFLICT(...) DO UPDATE SET snr = COALESCE(excluded.snr, snr), rssi = ..., score = ...`. A later arrival with SNR fills in a `NULL`; a later arrival without SNR does not overwrite an existing value.

## Tests

- `TestIATAFilterDoesNotDropStatusMessages` — verifies BFL status message is processed when IATA filter includes only SJC, and that BFL packet is still filtered
- `TestInsertObservationSNRFillIn` — verifies SNR fills in on second arrival, and is not overwritten by a subsequent null arrival

## Related

Partially addresses #694 (upstream client issue of missing SNR in packet messages is out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)