### PR TITLE
feat: scope stats (#899) + multibyte capability map overlay (#903)

### DIFF
--- a/cmd/ingestor/config.go
+++ b/cmd/ingestor/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	ChannelKeysPath string            `json:"channelKeysPath,omitempty"`
 	ChannelKeys     map[string]string `json:"channelKeys,omitempty"`
 	HashChannels    []string          `json:"hashChannels,omitempty"`
+	HashRegions     []string          `json:"hashRegions,omitempty"`
 	Retention       *RetentionConfig  `json:"retention,omitempty"`
 	Metrics         *MetricsConfig    `json:"metrics,omitempty"`
 	GeoFilter            *GeoFilterConfig  `json:"geo_filter,omitempty"`

--- a/cmd/ingestor/coverage_boost_test.go
+++ b/cmd/ingestor/coverage_boost_test.go
@@ -158,7 +158,7 @@ func TestHandleMessageChannelMessage(t *testing.T) {
 	payload := []byte(`{"text":"Alice: Hello everyone","channel_idx":3,"SNR":5.0,"RSSI":-95,"score":10,"direction":"rx","sender_timestamp":1700000000}`)
 	msg := &mockMessage{topic: "meshcore/message/channel/2", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -218,7 +218,7 @@ func TestHandleMessageChannelMessageEmptyText(t *testing.T) {
 	store, source := newTestContext(t)
 
 	msg := &mockMessage{topic: "meshcore/message/channel/1", payload: []byte(`{"text":""}`)}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -233,7 +233,7 @@ func TestHandleMessageChannelNoSender(t *testing.T) {
 	store, source := newTestContext(t)
 
 	msg := &mockMessage{topic: "meshcore/message/channel/1", payload: []byte(`{"text":"no sender here"}`)}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM nodes").Scan(&count); err != nil {
@@ -250,7 +250,7 @@ func TestHandleMessageDirectMessage(t *testing.T) {
 	payload := []byte(`{"text":"Bob: Hey there","sender_timestamp":1700000000,"SNR":3.0,"rssi":-100,"Score":8,"Direction":"tx"}`)
 	msg := &mockMessage{topic: "meshcore/message/direct/abc123", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -294,7 +294,7 @@ func TestHandleMessageDirectMessageEmptyText(t *testing.T) {
 	store, source := newTestContext(t)
 
 	msg := &mockMessage{topic: "meshcore/message/direct/abc", payload: []byte(`{"text":""}`)}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -309,7 +309,7 @@ func TestHandleMessageDirectNoSender(t *testing.T) {
 	store, source := newTestContext(t)
 
 	msg := &mockMessage{topic: "meshcore/message/direct/xyz", payload: []byte(`{"text":"message with no colon"}`)}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -328,7 +328,7 @@ func TestHandleMessageUppercaseScoreDirection(t *testing.T) {
 	payload := []byte(`{"raw":"` + rawHex + `","Score":9.0,"Direction":"tx"}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var score *float64
 	var direction *string
@@ -349,7 +349,7 @@ func TestHandleMessageChannelLowercaseFields(t *testing.T) {
 
 	payload := []byte(`{"text":"Test: msg","snr":3.0,"rssi":-90,"Score":5,"Direction":"rx"}`)
 	msg := &mockMessage{topic: "meshcore/message/channel/0", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -365,7 +365,7 @@ func TestHandleMessageDirectLowercaseFields(t *testing.T) {
 
 	payload := []byte(`{"text":"Test: msg","snr":2.0,"rssi":-85,"score":7,"direction":"tx"}`)
 	msg := &mockMessage{topic: "meshcore/message/direct/xyz", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -388,7 +388,7 @@ func TestHandleMessageAdvertWithTelemetry(t *testing.T) {
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	// Should have created transmission, node, and observer
 	var txCount, nodeCount, obsCount int
@@ -428,7 +428,7 @@ func TestHandleMessageAdvertGeoFiltered(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/packets",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{GeoFilter: gf})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{GeoFilter: gf})
 
 	// Geo-filtered adverts should not create nodes
 	var nodeCount int
@@ -665,7 +665,7 @@ func TestHandleMessageCorruptedAdvertNoNode(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/packets",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM nodes").Scan(&count); err != nil {
@@ -687,7 +687,7 @@ func TestHandleMessageNonAdvertPacket(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/packets",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -864,7 +864,7 @@ func TestHandleMessageChannelLongSender(t *testing.T) {
 	longText := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA: msg"
 	payload := []byte(`{"text":"` + longText + `"}`)
 	msg := &mockMessage{topic: "meshcore/message/channel/1", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM nodes").Scan(&count); err != nil {
@@ -883,7 +883,7 @@ func TestHandleMessageDirectLongSender(t *testing.T) {
 	longText := "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB: msg"
 	payload := []byte(`{"text":"` + longText + `"}`)
 	msg := &mockMessage{topic: "meshcore/message/direct/abc", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -900,7 +900,7 @@ func TestHandleMessageDirectUppercaseScoreDirection(t *testing.T) {
 
 	payload := []byte(`{"text":"X: hi","Score":6,"Direction":"rx"}`)
 	msg := &mockMessage{topic: "meshcore/message/direct/d1", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -930,7 +930,7 @@ func TestHandleMessageChannelUppercaseScoreDirection(t *testing.T) {
 
 	payload := []byte(`{"text":"Y: hi","Score":4,"Direction":"tx"}`)
 	msg := &mockMessage{topic: "meshcore/message/channel/5", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count); err != nil {
@@ -961,7 +961,7 @@ func TestHandleMessageRawLowercaseScore(t *testing.T) {
 	rawHex := "0A00D69FD7A5A7475DB07337749AE61FA53A4788E976"
 	payload := []byte(`{"raw":"` + rawHex + `","score":3.5}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var score *float64
 	if err := store.db.QueryRow("SELECT score FROM observations LIMIT 1").Scan(&score); err != nil {
@@ -980,7 +980,7 @@ func TestHandleMessageStatusNoOrigin(t *testing.T) {
 		topic:   "meshcore/LAX/obs5/status",
 		payload: []byte(`{"model":"L1"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	if err := store.db.QueryRow("SELECT COUNT(*) FROM observers WHERE id = 'obs5'").Scan(&count); err != nil {

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -418,6 +418,16 @@ func applySchema(db *sql.DB) error {
 		log.Println("[migration] observations.raw_hex column added")
 	}
 
+	// Migration: add scope_name column to transmissions (#899)
+	row = db.QueryRow("SELECT 1 FROM _migrations WHERE name = 'scope_name_v1'")
+	if row.Scan(&migDone) != nil {
+		log.Println("[migration] Adding scope_name column to transmissions...")
+		db.Exec(`ALTER TABLE transmissions ADD COLUMN scope_name TEXT DEFAULT NULL`)
+		db.Exec(`CREATE INDEX IF NOT EXISTS idx_tx_scope_name ON transmissions(scope_name) WHERE scope_name IS NOT NULL`)
+		db.Exec(`INSERT INTO _migrations (name) VALUES ('scope_name_v1')`)
+		log.Println("[migration] scope_name column added")
+	}
+
 	return nil
 }
 
@@ -902,6 +912,53 @@ func (s *Store) PruneDroppedPackets(retentionDays int) (int64, error) {
 		log.Printf("Pruned %d dropped packet(s) older than %d days", n, retentionDays)
 	}
 	return n, nil
+}
+
+// BackfillScopeNames sets scope_name on existing transport-route transmissions that
+// lack it, using the provided region HMAC keys. Safe to re-run — only processes
+// rows where scope_name IS NULL and route_type IN (0, 3).
+func (s *Store) BackfillScopeNames(regionKeys map[string][]byte) {
+	if len(regionKeys) == 0 {
+		return
+	}
+	rows, err := s.db.Query(`
+		SELECT id, raw_hex FROM transmissions
+		WHERE route_type IN (0, 3) AND scope_name IS NULL AND raw_hex IS NOT NULL
+	`)
+	if err != nil {
+		log.Printf("[backfill] scope_name query: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	type row struct {
+		id     int64
+		rawHex string
+	}
+	var pending []row
+	for rows.Next() {
+		var r row
+		if rows.Scan(&r.id, &r.rawHex) == nil && r.rawHex != "" {
+			pending = append(pending, r)
+		}
+	}
+
+	updated := 0
+	for _, r := range pending {
+		decoded, err := DecodePacket(r.rawHex, nil, false)
+		if err != nil || decoded.TransportCodes == nil {
+			continue
+		}
+		if decoded.TransportCodes.Code1 == "0000" {
+			continue
+		}
+		scopeName := matchScope(regionKeys, byte(decoded.Header.PayloadType), decoded.PayloadRaw, decoded.TransportCodes.Code1)
+		s.db.Exec(`UPDATE transmissions SET scope_name = ? WHERE id = ?`, scopeName, r.id)
+		updated++
+	}
+	if updated > 0 {
+		log.Printf("[backfill] scope_name set for %d/%d transport-route rows", updated, len(pending))
+	}
 }
 
 // PacketData holds the data needed to insert a packet into the DB.

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -915,56 +915,6 @@ func (s *Store) PruneDroppedPackets(retentionDays int) (int64, error) {
 	return n, nil
 }
 
-// BackfillScopeNames sets scope_name on existing transport-route transmissions that
-// lack it, using the provided region HMAC keys. Safe to re-run — only processes
-// rows where scope_name IS NULL and route_type IN (0, 3).
-func (s *Store) BackfillScopeNames(regionKeys map[string][]byte) {
-	if len(regionKeys) == 0 {
-		return
-	}
-	rows, err := s.db.Query(`
-		SELECT id, raw_hex FROM transmissions
-		WHERE route_type IN (0, 3) AND scope_name IS NULL AND raw_hex IS NOT NULL
-	`)
-	if err != nil {
-		log.Printf("[backfill] scope_name query: %v", err)
-		return
-	}
-	defer rows.Close()
-
-	type row struct {
-		id     int64
-		rawHex string
-	}
-	var pending []row
-	for rows.Next() {
-		var r row
-		if rows.Scan(&r.id, &r.rawHex) == nil && r.rawHex != "" {
-			pending = append(pending, r)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		log.Printf("[backfill] scope_name iteration error: %v", err)
-		return
-	}
-
-	updated := 0
-	for _, r := range pending {
-		decoded, err := DecodePacket(r.rawHex, nil, false)
-		if err != nil || decoded.TransportCodes == nil {
-			continue
-		}
-		if decoded.TransportCodes.Code1 == "0000" {
-			continue
-		}
-		scopeName := matchScope(regionKeys, byte(decoded.Header.PayloadType), decoded.PayloadRaw, decoded.TransportCodes.Code1)
-		s.db.Exec(`UPDATE transmissions SET scope_name = ? WHERE id = ?`, scopeName, r.id)
-		updated++
-	}
-	if updated > 0 {
-		log.Printf("[backfill] scope_name set for %d/%d transport-route rows", updated, len(pending))
-	}
-}
 
 // PacketData holds the data needed to insert a packet into the DB.
 type PacketData struct {

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -440,8 +440,8 @@ func (s *Store) prepareStatements() error {
 	}
 
 	s.stmtInsertTransmission, err = s.db.Prepare(`
-		INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, payload_version, decoded_json, channel_hash)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, payload_version, decoded_json, channel_hash, scope_name)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return err
@@ -570,6 +570,7 @@ func (s *Store) InsertTransmission(data *PacketData) (bool, error) {
 			data.RawHex, hash, now,
 			data.RouteType, data.PayloadType, data.PayloadVersion,
 			data.DecodedJSON, nilIfEmpty(data.ChannelHash),
+			scopeNameForDB(data),
 		)
 		if err != nil {
 			s.Stats.WriteErrors.Add(1)
@@ -967,21 +968,23 @@ func (s *Store) BackfillScopeNames(regionKeys map[string][]byte) {
 
 // PacketData holds the data needed to insert a packet into the DB.
 type PacketData struct {
-	RawHex         string
-	Timestamp      string
-	ObserverID     string
-	ObserverName   string
-	SNR            *float64
-	RSSI           *float64
-	Score          *float64
-	Direction      *string
-	Hash           string
-	RouteType      int
-	PayloadType    int
-	PayloadVersion int
-	PathJSON       string
-	DecodedJSON    string
-	ChannelHash    string // grouping key for channel queries (#762)
+	RawHex            string
+	Timestamp         string
+	ObserverID        string
+	ObserverName      string
+	SNR               *float64
+	RSSI              *float64
+	Score             *float64
+	Direction         *string
+	Hash              string
+	RouteType         int
+	PayloadType       int
+	PayloadVersion    int
+	PathJSON          string
+	DecodedJSON       string
+	ChannelHash       string // grouping key for channel queries (#762)
+	ScopeName         string // matched region name, or "" for unknown-scoped
+	IsTransportScoped bool   // true when route_type IN (0,3) AND Code1 ≠ "0000"
 }
 
 // nilIfEmpty returns nil for empty strings (for nullable DB columns).
@@ -990,6 +993,15 @@ func nilIfEmpty(s string) interface{} {
 		return nil
 	}
 	return s
+}
+
+// scopeNameForDB encodes PacketData scope semantics for DB storage:
+// non-transport-scoped → NULL; transport-scoped → ScopeName (may be "" for unknown).
+func scopeNameForDB(data *PacketData) interface{} {
+	if !data.IsTransportScoped {
+		return nil
+	}
+	return data.ScopeName // "" or "#regionname"
 }
 
 // MQTTPacketMessage is the JSON payload from an MQTT raw packet message.
@@ -1006,7 +1018,7 @@ type MQTTPacketMessage struct {
 // path_json is derived directly from raw_hex header bytes (not decoded.Path.Hops)
 // to guarantee the stored path always matches the raw bytes. This matters for
 // TRACE packets where decoded.Path.Hops is overwritten with payload hops (#886).
-func BuildPacketData(msg *MQTTPacketMessage, decoded *DecodedPacket, observerID, region string) *PacketData {
+func BuildPacketData(msg *MQTTPacketMessage, decoded *DecodedPacket, observerID, region string, regionKeys map[string][]byte) *PacketData {
 	now := time.Now().UTC().Format(time.RFC3339)
 	pathJSON := "[]"
 	// For TRACE packets, path_json must be the payload-decoded route hops
@@ -1046,6 +1058,11 @@ func BuildPacketData(msg *MQTTPacketMessage, decoded *DecodedPacket, observerID,
 		} else if decoded.Payload.Type == "GRP_TXT" && decoded.Payload.ChannelHashHex != "" {
 			pd.ChannelHash = "enc_" + decoded.Payload.ChannelHashHex
 		}
+	}
+
+	if decoded.TransportCodes != nil && decoded.TransportCodes.Code1 != "0000" {
+		pd.IsTransportScoped = true
+		pd.ScopeName = matchScope(regionKeys, byte(decoded.Header.PayloadType), decoded.PayloadRaw, decoded.TransportCodes.Code1)
 	}
 
 	return pd

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -428,6 +428,18 @@ func applySchema(db *sql.DB) error {
 		log.Println("[migration] scope_name column added")
 	}
 
+	// Migration: add multibyte capability columns to nodes/inactive_nodes (#903)
+	row = db.QueryRow("SELECT 1 FROM _migrations WHERE name = 'multibyte_sup_v1'")
+	if row.Scan(&migDone) != nil {
+		log.Println("[migration] Adding multibyte_sup columns to nodes/inactive_nodes...")
+		db.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0`)
+		db.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_evidence TEXT`)
+		db.Exec(`ALTER TABLE inactive_nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0`)
+		db.Exec(`ALTER TABLE inactive_nodes ADD COLUMN multibyte_evidence TEXT`)
+		db.Exec(`INSERT INTO _migrations (name) VALUES ('multibyte_sup_v1')`)
+		log.Println("[migration] multibyte_sup columns added")
+	}
+
 	return nil
 }
 

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -942,6 +942,10 @@ func (s *Store) BackfillScopeNames(regionKeys map[string][]byte) {
 			pending = append(pending, r)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[backfill] scope_name iteration error: %v", err)
+		return
+	}
 
 	updated := 0
 	for _, r := range pending {

--- a/cmd/ingestor/db_test.go
+++ b/cmd/ingestor/db_test.go
@@ -590,7 +590,7 @@ func TestEndToEndIngest(t *testing.T) {
 	msg := &MQTTPacketMessage{
 		Raw: rawHex,
 	}
-	pktData := BuildPacketData(msg, decoded, "obs1", "SJC")
+	pktData := BuildPacketData(msg, decoded, "obs1", "SJC", nil)
 	if _, err := s.InsertTransmission(pktData); err != nil {
 		t.Fatal(err)
 	}
@@ -784,7 +784,7 @@ func TestBuildPacketData(t *testing.T) {
 		Origin: "test-observer",
 	}
 
-	pkt := BuildPacketData(msg, decoded, "obs123", "SJC")
+	pkt := BuildPacketData(msg, decoded, "obs123", "SJC", nil)
 
 	if pkt.RawHex != rawHex {
 		t.Errorf("rawHex mismatch")
@@ -829,7 +829,7 @@ func TestBuildPacketDataWithHops(t *testing.T) {
 		t.Fatal(err)
 	}
 	msg := &MQTTPacketMessage{Raw: raw}
-	pkt := BuildPacketData(msg, decoded, "", "")
+	pkt := BuildPacketData(msg, decoded, "", "", nil)
 
 	if pkt.PathJSON == "[]" {
 		t.Error("pathJSON should contain hops")
@@ -842,7 +842,7 @@ func TestBuildPacketDataWithHops(t *testing.T) {
 func TestBuildPacketDataNilSNRRSSI(t *testing.T) {
 	decoded, _ := DecodePacket("0A00"+strings.Repeat("00", 10), nil, false)
 	msg := &MQTTPacketMessage{Raw: "0A00" + strings.Repeat("00", 10)}
-	pkt := BuildPacketData(msg, decoded, "", "")
+	pkt := BuildPacketData(msg, decoded, "", "", nil)
 
 	if pkt.SNR != nil {
 		t.Errorf("SNR should be nil")
@@ -1643,7 +1643,7 @@ func TestBuildPacketDataScoreAndDirection(t *testing.T) {
 		Direction: &dir,
 	}
 
-	pkt := BuildPacketData(msg, decoded, "obs1", "SJC")
+	pkt := BuildPacketData(msg, decoded, "obs1", "SJC", nil)
 	if pkt.Score == nil || *pkt.Score != 42.0 {
 		t.Errorf("Score=%v, want 42.0", pkt.Score)
 	}
@@ -1655,7 +1655,7 @@ func TestBuildPacketDataScoreAndDirection(t *testing.T) {
 func TestBuildPacketDataNilScoreDirection(t *testing.T) {
 	decoded, _ := DecodePacket("0A00"+strings.Repeat("00", 10), nil, false)
 	msg := &MQTTPacketMessage{Raw: "0A00" + strings.Repeat("00", 10)}
-	pkt := BuildPacketData(msg, decoded, "", "")
+	pkt := BuildPacketData(msg, decoded, "", "", nil)
 
 	if pkt.Score != nil {
 		t.Errorf("Score should be nil, got %v", *pkt.Score)
@@ -2087,7 +2087,7 @@ func TestBuildPacketData_TraceUsesPayloadHops(t *testing.T) {
 	}
 
 	msg := &MQTTPacketMessage{Raw: rawHex}
-	pd := BuildPacketData(msg, decoded, "test-obs", "TST")
+	pd := BuildPacketData(msg, decoded, "test-obs", "TST", nil)
 
 	// For TRACE: path_json MUST be the payload-decoded route hops, NOT the SNR bytes
 	expectedPathJSON := `["67","33","D6","33","67"]`
@@ -2119,7 +2119,7 @@ func TestBuildPacketData_NonTracePathJSON(t *testing.T) {
 	}
 
 	msg := &MQTTPacketMessage{Raw: rawHex}
-	pd := BuildPacketData(msg, decoded, "obs1", "TST")
+	pd := BuildPacketData(msg, decoded, "obs1", "TST", nil)
 
 	expectedPathJSON := `["AA","BB"]`
 	if pd.PathJSON != expectedPathJSON {

--- a/cmd/ingestor/db_test.go
+++ b/cmd/ingestor/db_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -2121,5 +2124,85 @@ func TestBuildPacketData_NonTracePathJSON(t *testing.T) {
 	expectedPathJSON := `["AA","BB"]`
 	if pd.PathJSON != expectedPathJSON {
 		t.Errorf("path_json = %s, want %s", pd.PathJSON, expectedPathJSON)
+	}
+}
+
+func TestScopeNameMigration(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	// Verify scope_name column exists
+	rows, err := store.db.Query("PRAGMA table_info(transmissions)")
+	if err != nil {
+		t.Fatalf("PRAGMA: %v", err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var cid int
+		var colName, colType string
+		var notNull, pk int
+		var dflt interface{}
+		if err := rows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk); err == nil {
+			if colName == "scope_name" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("scope_name column not found in transmissions")
+	}
+}
+
+func TestBackfillScopeNames(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenStore(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	// Insert a transport-route packet with known Code1
+	regionName := "#test"
+	h := sha256.Sum256([]byte(regionName))
+	key := h[:16]
+	payloadType := byte(0x05)
+	payloadRaw := []byte("hello")
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte{payloadType})
+	mac.Write(payloadRaw)
+	hmacBytes := mac.Sum(nil)
+	code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+	if code == 0 {
+		code = 1
+	} else if code == 0xFFFF {
+		code = 0xFFFE
+	}
+	codeBytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+
+	// Build raw packet bytes: header(1) + Code1(2) + Code2(2) + path_len(1) + payload
+	header := byte(0x00) | (payloadType << 2) // TRANSPORT_FLOOD + payload_type in bits 2-5
+	raw := []byte{header}
+	raw = append(raw, codeBytes[:]...)
+	raw = append(raw, 0x00, 0x00) // Code2 = 0000
+	raw = append(raw, 0x00)       // path_len = 0 hops
+	raw = append(raw, payloadRaw...)
+	rawHex := strings.ToUpper(hex.EncodeToString(raw))
+
+	store.db.Exec(`INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, payload_version, decoded_json)
+		VALUES (?, 'testhash1', datetime('now'), 0, 5, 0, '{}')`, rawHex)
+
+	store.BackfillScopeNames(map[string][]byte{regionName: key})
+
+	var scopeName *string
+	store.db.QueryRow(`SELECT scope_name FROM transmissions WHERE hash = 'testhash1'`).Scan(&scopeName)
+	if scopeName == nil || *scopeName != regionName {
+		t.Errorf("scope_name = %v, want %q", scopeName, regionName)
 	}
 }

--- a/cmd/ingestor/db_test.go
+++ b/cmd/ingestor/db_test.go
@@ -516,6 +516,30 @@ func TestSchemaMultibyteSupColumns(t *testing.T) {
 	if _, ok := cols["multibyte_evidence"]; !ok {
 		t.Error("nodes.multibyte_evidence column missing")
 	}
+
+	inactiveCols := map[string]string{}
+	inactiveRows, err := s.db.Query("PRAGMA table_info(inactive_nodes)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inactiveRows.Close()
+	for inactiveRows.Next() {
+		var cid int
+		var colName, colType string
+		var notNull, pk int
+		var dflt interface{}
+		if inactiveRows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk) == nil {
+			inactiveCols[colName] = colType
+		}
+	}
+	if ct, ok := inactiveCols["multibyte_sup"]; !ok {
+		t.Error("inactive_nodes.multibyte_sup column missing")
+	} else if ct != "INTEGER" {
+		t.Errorf("inactive_nodes.multibyte_sup type=%s, want INTEGER", ct)
+	}
+	if _, ok := inactiveCols["multibyte_evidence"]; !ok {
+		t.Error("inactive_nodes.multibyte_evidence column missing")
+	}
 }
 
 func TestInsertTransmissionWithObserver(t *testing.T) {

--- a/cmd/ingestor/db_test.go
+++ b/cmd/ingestor/db_test.go
@@ -485,6 +485,39 @@ func TestSchemaNoiseFloorIsReal(t *testing.T) {
 	}
 }
 
+func TestSchemaMultibyteSupColumns(t *testing.T) {
+	s, err := OpenStore(tempDBPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	cols := map[string]string{}
+	rows, err := s.db.Query("PRAGMA table_info(nodes)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var colName, colType string
+		var notNull, pk int
+		var dflt interface{}
+		if rows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk) == nil {
+			cols[colName] = colType
+		}
+	}
+
+	if ct, ok := cols["multibyte_sup"]; !ok {
+		t.Error("nodes.multibyte_sup column missing")
+	} else if ct != "INTEGER" {
+		t.Errorf("nodes.multibyte_sup type=%s, want INTEGER", ct)
+	}
+	if _, ok := cols["multibyte_evidence"]; !ok {
+		t.Error("nodes.multibyte_evidence column missing")
+	}
+}
+
 func TestInsertTransmissionWithObserver(t *testing.T) {
 	s, err := OpenStore(tempDBPath(t))
 	if err != nil {

--- a/cmd/ingestor/db_test.go
+++ b/cmd/ingestor/db_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -2159,50 +2156,3 @@ func TestScopeNameMigration(t *testing.T) {
 	}
 }
 
-func TestBackfillScopeNames(t *testing.T) {
-	dir := t.TempDir()
-	store, err := OpenStore(filepath.Join(dir, "test.db"))
-	if err != nil {
-		t.Fatalf("OpenStore: %v", err)
-	}
-	defer store.Close()
-
-	// Insert a transport-route packet with known Code1
-	regionName := "#test"
-	h := sha256.Sum256([]byte(regionName))
-	key := h[:16]
-	payloadType := byte(0x05)
-	payloadRaw := []byte("hello")
-
-	mac := hmac.New(sha256.New, key)
-	mac.Write([]byte{payloadType})
-	mac.Write(payloadRaw)
-	hmacBytes := mac.Sum(nil)
-	code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
-	if code == 0 {
-		code = 1
-	} else if code == 0xFFFF {
-		code = 0xFFFE
-	}
-	codeBytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
-
-	// Build raw packet bytes: header(1) + Code1(2) + Code2(2) + path_len(1) + payload
-	header := byte(0x00) | (payloadType << 2) // TRANSPORT_FLOOD + payload_type in bits 2-5
-	raw := []byte{header}
-	raw = append(raw, codeBytes[:]...)
-	raw = append(raw, 0x00, 0x00) // Code2 = 0000
-	raw = append(raw, 0x00)       // path_len = 0 hops
-	raw = append(raw, payloadRaw...)
-	rawHex := strings.ToUpper(hex.EncodeToString(raw))
-
-	store.db.Exec(`INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, payload_version, decoded_json)
-		VALUES (?, 'testhash1', datetime('now'), 0, 5, 0, '{}')`, rawHex)
-
-	store.BackfillScopeNames(map[string][]byte{regionName: key})
-
-	var scopeName *string
-	store.db.QueryRow(`SELECT scope_name FROM transmissions WHERE hash = 'testhash1'`).Scan(&scopeName)
-	if scopeName == nil || *scopeName != regionName {
-		t.Errorf("scope_name = %v, want %q", scopeName, regionName)
-	}
-}

--- a/cmd/ingestor/decoder.go
+++ b/cmd/ingestor/decoder.go
@@ -146,6 +146,7 @@ type DecodedPacket struct {
 	Payload        Payload         `json:"payload"`
 	Raw            string          `json:"raw"`
 	Anomaly        string          `json:"anomaly,omitempty"`
+	PayloadRaw     []byte          `json:"-"`
 }
 
 func decodeHeader(b byte) Header {
@@ -639,6 +640,7 @@ func DecodePacket(hexString string, channelKeys map[string]string, validateSigna
 		Payload:        payload,
 		Raw:            strings.ToUpper(hexString),
 		Anomaly:        anomaly,
+		PayloadRaw:     payloadBuf,
 	}, nil
 }
 

--- a/cmd/ingestor/decoder_test.go
+++ b/cmd/ingestor/decoder_test.go
@@ -447,6 +447,28 @@ func TestValidateAdvert(t *testing.T) {
 	}
 }
 
+func TestDecodePacketPayloadRaw(t *testing.T) {
+	// Build a minimal TRANSPORT_FLOOD packet (route_type=0):
+	// header(1) + transport_codes(4) + path_len(1) + payload(N)
+	// Header 0x00 = route_type=TRANSPORT_FLOOD, payload_type=0, version=0
+	// Code1=9A52, Code2=0000, path_len=0x00 (0 hops, hash_size=1)
+	payload := []byte("hello")
+	raw := []byte{0x00, 0x9A, 0x52, 0x00, 0x00, 0x00}
+	raw = append(raw, payload...)
+	hexStr := strings.ToUpper(hex.EncodeToString(raw))
+
+	decoded, err := DecodePacket(hexStr, nil, false)
+	if err != nil {
+		t.Fatalf("DecodePacket: %v", err)
+	}
+	if decoded.TransportCodes == nil {
+		t.Fatal("expected TransportCodes, got nil")
+	}
+	if string(decoded.PayloadRaw) != string(payload) {
+		t.Errorf("PayloadRaw = %v, want %v", decoded.PayloadRaw, payload)
+	}
+}
+
 func TestDecodeGrpTxtShort(t *testing.T) {
 	p := decodeGrpTxt([]byte{0x01, 0x02}, nil)
 	if p.Error != "too short" {

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
@@ -808,6 +809,51 @@ func loadChannelKeys(cfg *Config, configPath string) map[string]string {
 	}
 
 	return keys
+}
+
+func loadRegionKeys(cfg *Config) map[string][]byte {
+	keys := make(map[string][]byte)
+	for _, raw := range cfg.HashRegions {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(name, "#") {
+			name = "#" + name
+		}
+		if _, exists := keys[name]; exists {
+			continue
+		}
+		h := sha256.Sum256([]byte(name))
+		keys[name] = h[:16]
+	}
+	if len(keys) > 0 {
+		log.Printf("[regions] %d region key(s) loaded", len(keys))
+	}
+	return keys
+}
+
+func matchScope(regionKeys map[string][]byte, payloadType byte, payloadRaw []byte, code1 string) string {
+	if code1 == "0000" || len(regionKeys) == 0 || len(payloadRaw) == 0 {
+		return ""
+	}
+	for name, key := range regionKeys {
+		mac := hmac.New(sha256.New, key)
+		mac.Write([]byte{payloadType})
+		mac.Write(payloadRaw)
+		hmacBytes := mac.Sum(nil)
+		code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+		if code == 0 {
+			code = 1
+		} else if code == 0xFFFF {
+			code = 0xFFFE
+		}
+		codeBytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+		if strings.ToUpper(hex.EncodeToString(codeBytes[:])) == code1 {
+			return name
+		}
+	}
+	return ""
 }
 
 // Version info (set via ldflags)

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -113,6 +113,9 @@ func main() {
 		log.Printf("No channel keys loaded — GRP_TXT packets will not be decrypted")
 	}
 
+	regionKeys := loadRegionKeys(cfg)
+	go store.BackfillScopeNames(regionKeys)
+
 	// Connect to each MQTT source
 	var clients []mqtt.Client
 	for _, source := range sources {
@@ -163,7 +166,7 @@ func main() {
 		// Capture source for closure
 		src := source
 		opts.SetDefaultPublishHandler(func(c mqtt.Client, m mqtt.Message) {
-			handleMessage(store, tag, src, m, channelKeys, cfg)
+			handleMessage(store, tag, src, m, channelKeys, regionKeys, cfg)
 		})
 
 		client := mqtt.NewClient(opts)
@@ -198,7 +201,7 @@ func main() {
 	log.Println("Done.")
 }
 
-func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, channelKeys map[string]string, cfg *Config) {
+func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, channelKeys map[string]string, regionKeys map[string][]byte, cfg *Config) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("MQTT [%s] panic in handler: %v", tag, r)
@@ -352,7 +355,7 @@ func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, 
 			if !NodePassesGeoFilter(decoded.Payload.Lat, decoded.Payload.Lon, cfg.GeoFilter) {
 				return
 			}
-			pktData := BuildPacketData(mqttMsg, decoded, observerID, region)
+			pktData := BuildPacketData(mqttMsg, decoded, observerID, region, regionKeys)
 			isNew, err := store.InsertTransmission(pktData)
 			if err != nil {
 				log.Printf("MQTT [%s] db insert error: %v", tag, err)
@@ -375,7 +378,7 @@ func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, 
 		} else {
 			// Non-ADVERT packets: store normally (routing/channel messages from
 			// in-area observers are relevant regardless of relay hop origin).
-			pktData := BuildPacketData(mqttMsg, decoded, observerID, region)
+			pktData := BuildPacketData(mqttMsg, decoded, observerID, region, regionKeys)
 			if _, err := store.InsertTransmission(pktData); err != nil {
 				log.Printf("MQTT [%s] db insert error: %v", tag, err)
 			}

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -114,7 +114,6 @@ func main() {
 	}
 
 	regionKeys := loadRegionKeys(cfg)
-	go store.BackfillScopeNames(regionKeys)
 
 	// Connect to each MQTT source
 	var clients []mqtt.Client

--- a/cmd/ingestor/main_test.go
+++ b/cmd/ingestor/main_test.go
@@ -135,7 +135,7 @@ func TestHandleMessageRawPacket(t *testing.T) {
 	payload := []byte(`{"raw":"` + rawHex + `","SNR":5.5,"RSSI":-100.0,"origin":"myobs"}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -152,7 +152,7 @@ func TestHandleMessageRawPacketAdvert(t *testing.T) {
 	payload := []byte(`{"raw":"` + rawHex + `"}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	// Should create a node from the ADVERT
 	var count int
@@ -174,7 +174,7 @@ func TestHandleMessageInvalidJSON(t *testing.T) {
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: []byte(`not json`)}
 
 	// Should not panic
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -191,7 +191,7 @@ func TestHandleMessageStatusTopic(t *testing.T) {
 		payload: []byte(`{"origin":"MyObserver"}`),
 	}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var name, iata string
 	err := store.db.QueryRow("SELECT name, iata FROM observers WHERE id = 'obs1'").Scan(&name, &iata)
@@ -212,11 +212,11 @@ func TestHandleMessageSkipStatusTopics(t *testing.T) {
 
 	// meshcore/status should be skipped
 	msg1 := &mockMessage{topic: "meshcore/status", payload: []byte(`{"raw":"0A00"}`)}
-	handleMessage(store, "test", source, msg1, nil, &Config{})
+	handleMessage(store, "test", source, msg1, nil, nil, &Config{})
 
 	// meshcore/events/connection should be skipped
 	msg2 := &mockMessage{topic: "meshcore/events/connection", payload: []byte(`{"raw":"0A00"}`)}
-	handleMessage(store, "test", source, msg2, nil, &Config{})
+	handleMessage(store, "test", source, msg2, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -235,7 +235,7 @@ func TestHandleMessageIATAFilter(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/packets",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -248,7 +248,7 @@ func TestHandleMessageIATAFilter(t *testing.T) {
 		topic:   "meshcore/LAX/obs2/packets",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg2, nil, &Config{})
+	handleMessage(store, "test", source, msg2, nil, nil, &Config{})
 
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
 	if count != 1 {
@@ -266,7 +266,7 @@ func TestHandleMessageIATAFilterNoRegion(t *testing.T) {
 		topic:   "meshcore",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	// No region part → filter doesn't apply, message goes through
 	// Actually the code checks len(parts) > 1 for IATA filter
@@ -282,7 +282,7 @@ func TestHandleMessageNoRawHex(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/packets",
 		payload: []byte(`{"type":"companion","data":"something"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -300,7 +300,7 @@ func TestHandleMessageBadRawHex(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/packets",
 		payload: []byte(`{"raw":"ZZZZ"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -317,7 +317,7 @@ func TestHandleMessageWithSNRRSSIAsNumbers(t *testing.T) {
 	payload := []byte(`{"raw":"` + rawHex + `","SNR":7.2,"RSSI":-95}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var snr, rssi *float64
 	store.db.QueryRow("SELECT snr, rssi FROM observations LIMIT 1").Scan(&snr, &rssi)
@@ -336,7 +336,7 @@ func TestHandleMessageMinimalTopic(t *testing.T) {
 		topic:   "meshcore/SJC",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -357,7 +357,7 @@ func TestHandleMessageCorruptedAdvert(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/packets",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	// Transmission should be inserted (even if advert is invalid)
 	var count int
@@ -383,7 +383,7 @@ func TestHandleMessageNoObserverID(t *testing.T) {
 		topic:   "packets",
 		payload: []byte(`{"raw":"` + rawHex + `","origin":"obs1"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -405,7 +405,7 @@ func TestHandleMessageSNRNotFloat(t *testing.T) {
 	// SNR as a string value — should not parse as float
 	payload := []byte(`{"raw":"` + rawHex + `","SNR":"bad","RSSI":"bad"}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
@@ -421,7 +421,7 @@ func TestHandleMessageOriginExtraction(t *testing.T) {
 	rawHex := "0A00D69FD7A5A7475DB07337749AE61FA53A4788E976"
 	payload := []byte(`{"raw":"` + rawHex + `","origin":"MyOrigin"}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	// Verify origin was extracted to observer name
 	var name string
@@ -444,7 +444,7 @@ func TestHandleMessagePanicRecovery(t *testing.T) {
 	}
 
 	// Should not panic — the defer/recover should catch it
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 }
 
 func TestHandleMessageStatusOriginFallback(t *testing.T) {
@@ -456,7 +456,7 @@ func TestHandleMessageStatusOriginFallback(t *testing.T) {
 		topic:   "meshcore/SJC/obs1/status",
 		payload: []byte(`{"type":"status"}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var name string
 	err := store.db.QueryRow("SELECT name FROM observers WHERE id = 'obs1'").Scan(&name)
@@ -645,7 +645,7 @@ func TestHandleMessageWithLowercaseSNRRSSI(t *testing.T) {
 	payload := []byte(`{"raw":"` + rawHex + `","snr":5.5,"rssi":-102}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var snr, rssi *float64
 	store.db.QueryRow("SELECT snr, rssi FROM observations LIMIT 1").Scan(&snr, &rssi)
@@ -666,7 +666,7 @@ func TestHandleMessageSNRRSSIUppercaseWins(t *testing.T) {
 	payload := []byte(`{"raw":"` + rawHex + `","SNR":7.2,"snr":1.0,"RSSI":-95,"rssi":-50}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var snr, rssi *float64
 	store.db.QueryRow("SELECT snr, rssi FROM observations LIMIT 1").Scan(&snr, &rssi)
@@ -686,7 +686,7 @@ func TestHandleMessageNoSNRRSSI(t *testing.T) {
 	payload := []byte(`{"raw":"` + rawHex + `"}`)
 	msg := &mockMessage{topic: "meshcore/SJC/obs1/packets", payload: payload}
 
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var snr, rssi *float64
 	store.db.QueryRow("SELECT snr, rssi FROM observations LIMIT 1").Scan(&snr, &rssi)
@@ -757,7 +757,7 @@ func TestIATAFilterDoesNotDropStatusMessages(t *testing.T) {
 		topic:   "meshcore/BFL/bfl-obs1/status",
 		payload: []byte(`{"origin":"BFLObserver","stats":{"noise_floor":-105.0}}`),
 	}
-	handleMessage(store, "test", source, msg, nil, &Config{})
+	handleMessage(store, "test", source, msg, nil, nil, &Config{})
 
 	var name string
 	var noiseFloor *float64
@@ -778,7 +778,7 @@ func TestIATAFilterDoesNotDropStatusMessages(t *testing.T) {
 		topic:   "meshcore/BFL/bfl-obs1/packets",
 		payload: []byte(`{"raw":"` + rawHex + `"}`),
 	}
-	handleMessage(store, "test", source, pktMsg, nil, &Config{})
+	handleMessage(store, "test", source, pktMsg, nil, nil, &Config{})
 	var count int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
 	if count != 0 {
@@ -847,5 +847,52 @@ func TestMatchScope(t *testing.T) {
 	// Scoped but no match → empty string sentinel
 	if got := matchScope(regionKeys, payloadType, payloadRaw, "BEEF"); got != "" {
 		t.Errorf("no match: matchScope = %q, want empty", got)
+	}
+}
+
+func TestBuildPacketDataScopeMatching(t *testing.T) {
+	// Build region key for "#test"
+	regionName := "#test"
+	h := sha256.Sum256([]byte(regionName))
+	key := h[:16]
+
+	payloadType := byte(0x05)
+	payloadRaw := []byte("hello")
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte{payloadType})
+	mac.Write(payloadRaw)
+	hmacBytes := mac.Sum(nil)
+	code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+	if code == 0 {
+		code = 1
+	} else if code == 0xFFFF {
+		code = 0xFFFE
+	}
+	codeBytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+
+	// TRANSPORT_FLOOD header with payloadType in bits 2-5
+	header := byte(0x00) | (payloadType << 2)
+	raw := []byte{header}
+	raw = append(raw, codeBytes[:]...)
+	raw = append(raw, 0x00, 0x00) // Code2
+	raw = append(raw, 0x00)       // path_len
+	raw = append(raw, payloadRaw...)
+	rawHex := strings.ToUpper(hex.EncodeToString(raw))
+
+	decoded, err := DecodePacket(rawHex, nil, false)
+	if err != nil {
+		t.Fatalf("DecodePacket: %v", err)
+	}
+
+	msg := &MQTTPacketMessage{Raw: rawHex}
+	regionKeys := map[string][]byte{regionName: key}
+
+	pktData := BuildPacketData(msg, decoded, "obs1", "region1", regionKeys)
+	if pktData.ScopeName != regionName {
+		t.Errorf("ScopeName = %q, want %q", pktData.ScopeName, regionName)
+	}
+	if !pktData.IsTransportScoped {
+		t.Error("IsTransportScoped should be true")
 	}
 }

--- a/cmd/ingestor/main_test.go
+++ b/cmd/ingestor/main_test.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -778,5 +783,69 @@ func TestIATAFilterDoesNotDropStatusMessages(t *testing.T) {
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
 	if count != 0 {
 		t.Error("packet from out-of-region BFL should still be filtered by IATA")
+	}
+}
+
+func TestLoadRegionKeys(t *testing.T) {
+	cfg := &Config{HashRegions: []string{"#belgium", "eu", "  #Test  ", "", "#belgium"}}
+	keys := loadRegionKeys(cfg)
+
+	// Deduplication + normalization
+	if len(keys) != 3 {
+		t.Fatalf("len(keys) = %d, want 3", len(keys))
+	}
+	// "#belgium" key = SHA256("#belgium")[:16]
+	h := sha256.Sum256([]byte("#belgium"))
+	want := h[:16]
+	if got := keys["#belgium"]; !bytes.Equal(got, want) {
+		t.Errorf("#belgium key mismatch: got %x, want %x", got, want)
+	}
+	// "eu" should be normalized to "#eu"
+	if _, ok := keys["#eu"]; !ok {
+		t.Error("expected #eu key")
+	}
+	// "  #Test  " should be normalized to "#Test"
+	if _, ok := keys["#Test"]; !ok {
+		t.Error("expected #Test key")
+	}
+}
+
+func TestMatchScope(t *testing.T) {
+	// Build a known Code1 for region "#test" and payload type 5, payload "hello"
+	name := "#test"
+	h := sha256.Sum256([]byte(name))
+	key := h[:16]
+
+	payloadType := byte(0x05)
+	payloadRaw := []byte("hello")
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte{payloadType})
+	mac.Write(payloadRaw)
+	hmacBytes := mac.Sum(nil)
+	code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+	if code == 0 {
+		code = 1
+	} else if code == 0xFFFF {
+		code = 0xFFFE
+	}
+	code1Bytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+	code1 := strings.ToUpper(hex.EncodeToString(code1Bytes[:]))
+
+	regionKeys := map[string][]byte{name: key}
+
+	got := matchScope(regionKeys, payloadType, payloadRaw, code1)
+	if got != name {
+		t.Errorf("matchScope = %q, want %q", got, name)
+	}
+
+	// Unscoped (Code1 = 0000) → empty
+	if got := matchScope(regionKeys, payloadType, payloadRaw, "0000"); got != "" {
+		t.Errorf("unscoped: matchScope = %q, want empty", got)
+	}
+
+	// Scoped but no match → empty string sentinel
+	if got := matchScope(regionKeys, payloadType, payloadRaw, "BEEF"); got != "" {
+		t.Errorf("no match: matchScope = %q, want empty", got)
 	}
 }

--- a/cmd/ingestor/sig_validate_ingest_test.go
+++ b/cmd/ingestor/sig_validate_ingest_test.go
@@ -61,7 +61,7 @@ func TestSigValidation_ValidAdvertStored(t *testing.T) {
 	msg := newMockMsg("meshcore/US/obs1/packet", `{"raw":"`+rawHex+`","origin":"TestObs"}`)
 	cfg := &Config{}
 
-	handleMessage(store, "test", source, msg, nil, cfg)
+	handleMessage(store, "test", source, msg, nil, nil, cfg)
 
 	// Verify packet was stored
 	var count int
@@ -98,7 +98,7 @@ func TestSigValidation_TamperedSignatureDropped(t *testing.T) {
 	msg := newMockMsg("meshcore/US/obs1/packet", `{"raw":"`+tamperedHex+`","origin":"TestObs"}`)
 	cfg := &Config{}
 
-	handleMessage(store, "test", source, msg, nil, cfg)
+	handleMessage(store, "test", source, msg, nil, nil, cfg)
 
 	// Verify packet was NOT stored in transmissions
 	var txCount int
@@ -157,7 +157,7 @@ func TestSigValidation_TruncatedAppdataDropped(t *testing.T) {
 	msg := newMockMsg("meshcore/US/obs1/packet", `{"raw":"`+truncatedHex+`","origin":"TestObs"}`)
 	cfg := &Config{}
 
-	handleMessage(store, "test", source, msg, nil, cfg)
+	handleMessage(store, "test", source, msg, nil, nil, cfg)
 
 	var txCount int
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&txCount)
@@ -192,7 +192,7 @@ func TestSigValidation_DisabledByConfig(t *testing.T) {
 	falseVal := false
 	cfg := &Config{ValidateSignatures: &falseVal}
 
-	handleMessage(store, "test", source, msg, nil, cfg)
+	handleMessage(store, "test", source, msg, nil, nil, cfg)
 
 	// With validation disabled, tampered packet should be stored
 	var txCount int
@@ -225,7 +225,7 @@ func TestSigValidation_DropCounterIncrements(t *testing.T) {
 			rawBytes[76] = '0'
 		}
 		msg := newMockMsg("meshcore/US/obs1/packet", `{"raw":"`+string(rawBytes)+`","origin":"Obs"}`)
-		handleMessage(store, "test", source, msg, nil, cfg)
+		handleMessage(store, "test", source, msg, nil, nil, cfg)
 	}
 
 	if store.Stats.SignatureDrops.Load() != 3 {
@@ -258,7 +258,7 @@ func TestSigValidation_LogContainsFields(t *testing.T) {
 	msg := newMockMsg("meshcore/US/obs1/packet", `{"raw":"`+string(rawBytes)+`","origin":"MyObserver"}`)
 	cfg := &Config{}
 
-	handleMessage(store, "test", source, msg, nil, cfg)
+	handleMessage(store, "test", source, msg, nil, nil, cfg)
 
 	var hash, reason, obsID, obsName, pubkey, nodeName string
 	err = store.db.QueryRow("SELECT hash, reason, observer_id, observer_name, node_pubkey, node_name FROM dropped_packets LIMIT 1").

--- a/cmd/server/bounded_load_test.go
+++ b/cmd/server/bounded_load_test.go
@@ -127,6 +127,92 @@ func TestBoundedLoad_AscendingOrder(t *testing.T) {
 	}
 }
 
+// loadStoreWithRetention creates a PacketStore with retentionHours set.
+func loadStoreWithRetention(t *testing.T, dbPath string, retentionHours float64) *PacketStore {
+	t.Helper()
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &PacketStoreConfig{RetentionHours: retentionHours}
+	store := NewPacketStore(db, cfg)
+	if err := store.Load(); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+// createTestDBWithAgedPackets inserts numRecent packets with timestamps within
+// the last hour and numOld packets with timestamps 48 hours ago.
+func createTestDBWithAgedPackets(t *testing.T, numRecent, numOld int) string {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	conn, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	execOrFail := func(s string) {
+		if _, err := conn.Exec(s); err != nil {
+			t.Fatalf("setup: %v\nSQL: %s", err, s)
+		}
+	}
+	execOrFail(`CREATE TABLE transmissions (id INTEGER PRIMARY KEY, raw_hex TEXT, hash TEXT, first_seen TEXT, route_type INTEGER, payload_type INTEGER, payload_version INTEGER, decoded_json TEXT)`)
+	execOrFail(`CREATE TABLE observations (id INTEGER PRIMARY KEY, transmission_id INTEGER, observer_id TEXT, observer_name TEXT, direction TEXT, snr REAL, rssi REAL, score INTEGER, path_json TEXT, timestamp TEXT, raw_hex TEXT)`)
+	execOrFail(`CREATE TABLE observers (rowid INTEGER PRIMARY KEY, id TEXT, name TEXT)`)
+	execOrFail(`CREATE TABLE nodes (pubkey TEXT PRIMARY KEY, name TEXT, role TEXT, lat REAL, lon REAL, last_seen TEXT, first_seen TEXT, frequency REAL)`)
+	execOrFail(`CREATE TABLE schema_version (version INTEGER)`)
+	execOrFail(`INSERT INTO schema_version (version) VALUES (1)`)
+	execOrFail(`CREATE INDEX idx_tx_first_seen ON transmissions(first_seen)`)
+
+	now := time.Now().UTC()
+	id := 1
+	// Insert old packets (48 hours ago)
+	for i := 0; i < numOld; i++ {
+		ts := now.Add(-48 * time.Hour).Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		conn.Exec("INSERT INTO transmissions VALUES (?,?,?,?,0,4,1,?)", id, "aa", fmt.Sprintf("old%d", i), ts, `{}`)
+		conn.Exec("INSERT INTO observations VALUES (?,?,?,?,?,?,?,?,?,?,?)", id, id, "obs1", "Obs1", "RX", -10.0, -80.0, 5, `[]`, ts, "")
+		id++
+	}
+	// Insert recent packets (within last hour)
+	for i := 0; i < numRecent; i++ {
+		ts := now.Add(-30 * time.Minute).Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		conn.Exec("INSERT INTO transmissions VALUES (?,?,?,?,0,4,1,?)", id, "bb", fmt.Sprintf("new%d", i), ts, `{}`)
+		conn.Exec("INSERT INTO observations VALUES (?,?,?,?,?,?,?,?,?,?,?)", id, id, "obs1", "Obs1", "RX", -10.0, -80.0, 5, `[]`, ts, "")
+		id++
+	}
+	return dbPath
+}
+
+func TestRetentionLoad_OnlyLoadsRecentPackets(t *testing.T) {
+	dbPath := createTestDBWithAgedPackets(t, 50, 100)
+	defer os.RemoveAll(filepath.Dir(dbPath))
+
+	// retention = 2 hours — should load only the 50 recent packets, not the 100 old ones
+	store := loadStoreWithRetention(t, dbPath, 2)
+	defer store.db.conn.Close()
+
+	if len(store.packets) != 50 {
+		t.Errorf("expected 50 recent packets, got %d (old packets should be excluded by retentionHours)", len(store.packets))
+	}
+}
+
+func TestRetentionLoad_ZeroRetentionLoadsAll(t *testing.T) {
+	dbPath := createTestDBWithAgedPackets(t, 50, 100)
+	defer os.RemoveAll(filepath.Dir(dbPath))
+
+	// retention = 0 (unlimited) — should load all 150 packets
+	store := loadStoreWithRetention(t, dbPath, 0)
+	defer store.db.conn.Close()
+
+	if len(store.packets) != 150 {
+		t.Errorf("expected all 150 packets with retentionHours=0, got %d", len(store.packets))
+	}
+}
+
 func TestEstimateStoreTxBytesTypical(t *testing.T) {
 	est := estimateStoreTxBytesTypical(10)
 	if est < 1000 {

--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -21,6 +21,7 @@ type DB struct {
 	isV3             bool   // v3 schema: observer_idx in observations (vs observer_id in v2)
 	hasResolvedPath  bool   // observations table has resolved_path column
 	hasObsRawHex     bool   // observations table has raw_hex column (#881)
+	hasScopeName     bool   // transmissions.scope_name column exists (#899)
 
 	// Channel list cache (60s TTL) — avoids repeated GROUP BY scans (#762)
 	channelsCacheMu  sync.Mutex
@@ -79,6 +80,24 @@ func (db *DB) detectSchema() {
 			}
 			if colName == "raw_hex" {
 				db.hasObsRawHex = true
+			}
+		}
+	}
+
+	txRows, err := db.conn.Query("PRAGMA table_info(transmissions)")
+	if err != nil {
+		return
+	}
+	defer txRows.Close()
+	for txRows.Next() {
+		var cid int
+		var colName string
+		var colType sql.NullString
+		var notNull, pk int
+		var dflt sql.NullString
+		if txRows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk) == nil {
+			if colName == "scope_name" {
+				db.hasScopeName = true
 			}
 		}
 	}
@@ -2343,4 +2362,98 @@ func (db *DB) GetSignatureDropCount() int64 {
 		return 0
 	}
 	return count
+}
+
+func (db *DB) GetScopeStats(window string) (*ScopeStatsResponse, error) {
+	if !db.hasScopeName {
+		return nil, fmt.Errorf("scope_name column not present — run ingestor to apply migrations")
+	}
+
+	var since string
+	var bucketExpr string
+	switch window {
+	case "1h":
+		since = time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+		// 5-minute buckets
+		bucketExpr = `strftime('%Y-%m-%dT%H:', first_seen) || printf('%02d', (CAST(strftime('%M', first_seen) AS INTEGER) / 5) * 5) || ':00Z'`
+	case "7d":
+		since = time.Now().Add(-7 * 24 * time.Hour).UTC().Format(time.RFC3339)
+		// 6-hour buckets
+		bucketExpr = `strftime('%Y-%m-%dT', first_seen) || printf('%02d', (CAST(strftime('%H', first_seen) AS INTEGER) / 6) * 6) || ':00:00Z'`
+	default: // "24h"
+		window = "24h"
+		since = time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+		// 1-hour buckets
+		bucketExpr = `strftime('%Y-%m-%dT%H:00:00Z', first_seen)`
+	}
+
+	resp := &ScopeStatsResponse{Window: window}
+
+	// Summary counts
+	row := db.conn.QueryRow(`
+		SELECT
+			COUNT(*) AS transport_total,
+			COUNT(scope_name) AS scoped,
+			SUM(CASE WHEN scope_name IS NULL THEN 1 ELSE 0 END) AS unscoped,
+			SUM(CASE WHEN scope_name = '' THEN 1 ELSE 0 END) AS unknown_scope
+		FROM transmissions
+		WHERE route_type IN (0, 3) AND first_seen >= ?
+	`, since)
+	if err := row.Scan(
+		&resp.Summary.TransportTotal,
+		&resp.Summary.Scoped,
+		&resp.Summary.Unscoped,
+		&resp.Summary.UnknownScope,
+	); err != nil {
+		return nil, fmt.Errorf("scope summary query: %w", err)
+	}
+
+	// Per-region counts (named regions only)
+	rows, err := db.conn.Query(`
+		SELECT scope_name, COUNT(*) AS cnt
+		FROM transmissions
+		WHERE route_type IN (0, 3) AND scope_name IS NOT NULL AND scope_name != '' AND first_seen >= ?
+		GROUP BY scope_name
+		ORDER BY cnt DESC
+	`, since)
+	if err != nil {
+		return nil, fmt.Errorf("scope byRegion query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rc ScopeRegionCount
+		if rows.Scan(&rc.Name, &rc.Count) == nil {
+			resp.ByRegion = append(resp.ByRegion, rc)
+		}
+	}
+	if resp.ByRegion == nil {
+		resp.ByRegion = []ScopeRegionCount{}
+	}
+
+	// Time series
+	tsQuery := fmt.Sprintf(`
+		SELECT %s AS bucket,
+			COUNT(scope_name) AS scoped,
+			SUM(CASE WHEN scope_name IS NULL THEN 1 ELSE 0 END) AS unscoped
+		FROM transmissions
+		WHERE route_type IN (0, 3) AND first_seen >= ?
+		GROUP BY bucket
+		ORDER BY bucket
+	`, bucketExpr)
+	tsRows, err := db.conn.Query(tsQuery, since)
+	if err != nil {
+		return nil, fmt.Errorf("scope timeseries query: %w", err)
+	}
+	defer tsRows.Close()
+	for tsRows.Next() {
+		var pt ScopeTimePoint
+		if tsRows.Scan(&pt.T, &pt.Scoped, &pt.Unscoped) == nil {
+			resp.TimeSeries = append(resp.TimeSeries, pt)
+		}
+	}
+	if resp.TimeSeries == nil {
+		resp.TimeSeries = []ScopeTimePoint{}
+	}
+
+	return resp, nil
 }

--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -2394,8 +2394,8 @@ func (db *DB) GetScopeStats(window string) (*ScopeStatsResponse, error) {
 		SELECT
 			COUNT(*) AS transport_total,
 			COUNT(scope_name) AS scoped,
-			SUM(CASE WHEN scope_name IS NULL THEN 1 ELSE 0 END) AS unscoped,
-			SUM(CASE WHEN scope_name = '' THEN 1 ELSE 0 END) AS unknown_scope
+			COALESCE(SUM(CASE WHEN scope_name IS NULL THEN 1 ELSE 0 END), 0) AS unscoped,
+			COALESCE(SUM(CASE WHEN scope_name = '' THEN 1 ELSE 0 END), 0) AS unknown_scope
 		FROM transmissions
 		WHERE route_type IN (0, 3) AND first_seen >= ?
 	`, since)

--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -2426,6 +2426,9 @@ func (db *DB) GetScopeStats(window string) (*ScopeStatsResponse, error) {
 			resp.ByRegion = append(resp.ByRegion, rc)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("scope byRegion iteration: %w", err)
+	}
 	if resp.ByRegion == nil {
 		resp.ByRegion = []ScopeRegionCount{}
 	}
@@ -2450,6 +2453,9 @@ func (db *DB) GetScopeStats(window string) (*ScopeStatsResponse, error) {
 		if tsRows.Scan(&pt.T, &pt.Scoped, &pt.Unscoped) == nil {
 			resp.TimeSeries = append(resp.TimeSeries, pt)
 		}
+	}
+	if err := tsRows.Err(); err != nil {
+		return nil, fmt.Errorf("scope timeseries iteration: %w", err)
 	}
 	if resp.TimeSeries == nil {
 		resp.TimeSeries = []ScopeTimePoint{}

--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -20,8 +20,9 @@ type DB struct {
 	path             string // filesystem path to the database file
 	isV3             bool   // v3 schema: observer_idx in observations (vs observer_id in v2)
 	hasResolvedPath  bool   // observations table has resolved_path column
-	hasObsRawHex     bool   // observations table has raw_hex column (#881)
-	hasScopeName     bool   // transmissions.scope_name column exists (#899)
+	hasObsRawHex        bool   // observations table has raw_hex column (#881)
+	hasScopeName        bool   // transmissions.scope_name column exists (#899)
+	hasMultibyteSupCols bool   // nodes table has multibyte_sup/multibyte_evidence columns (#903)
 
 	// Channel list cache (60s TTL) — avoids repeated GROUP BY scans (#762)
 	channelsCacheMu  sync.Mutex
@@ -98,6 +99,24 @@ func (db *DB) detectSchema() {
 		if txRows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk) == nil {
 			if colName == "scope_name" {
 				db.hasScopeName = true
+			}
+		}
+	}
+
+	nodeRows, err := db.conn.Query("PRAGMA table_info(nodes)")
+	if err != nil {
+		return
+	}
+	defer nodeRows.Close()
+	for nodeRows.Next() {
+		var cid int
+		var colName string
+		var colType sql.NullString
+		var notNull, pk int
+		var dflt sql.NullString
+		if nodeRows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk) == nil {
+			if colName == "multibyte_sup" {
+				db.hasMultibyteSupCols = true
 			}
 		}
 	}
@@ -817,7 +836,11 @@ func (db *DB) GetNodes(limit, offset int, role, search, before, lastHeard, sortB
 	var total int
 	db.conn.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM nodes %s", w), args...).Scan(&total)
 
-	querySQL := fmt.Sprintf("SELECT public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c FROM nodes %s ORDER BY %s LIMIT ? OFFSET ?", w, order)
+	nodeColList := "public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c"
+	if db.hasMultibyteSupCols {
+		nodeColList += ", multibyte_sup, multibyte_evidence"
+	}
+	querySQL := fmt.Sprintf("SELECT %s FROM nodes %s ORDER BY %s LIMIT ? OFFSET ?", nodeColList, w, order)
 	qArgs := append(args, limit, offset)
 
 	rows, err := db.conn.Query(querySQL, qArgs...)
@@ -828,7 +851,7 @@ func (db *DB) GetNodes(limit, offset int, role, search, before, lastHeard, sortB
 
 	nodes := make([]map[string]interface{}, 0)
 	for rows.Next() {
-		n := scanNodeRow(rows)
+		n := db.scanNodeRow(rows)
 		if n != nil {
 			nodes = append(nodes, n)
 		}
@@ -843,8 +866,12 @@ func (db *DB) SearchNodes(query string, limit int) ([]map[string]interface{}, er
 	if limit <= 0 {
 		limit = 10
 	}
-	rows, err := db.conn.Query(`SELECT public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c
-		FROM nodes WHERE name LIKE ? OR public_key LIKE ? ORDER BY last_seen DESC LIMIT ?`,
+	colList := "public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c"
+	if db.hasMultibyteSupCols {
+		colList += ", multibyte_sup, multibyte_evidence"
+	}
+	rows, err := db.conn.Query(
+		fmt.Sprintf("SELECT %s FROM nodes WHERE name LIKE ? OR public_key LIKE ? ORDER BY last_seen DESC LIMIT ?", colList),
 		"%"+query+"%", query+"%", limit)
 	if err != nil {
 		return nil, err
@@ -853,7 +880,7 @@ func (db *DB) SearchNodes(query string, limit int) ([]map[string]interface{}, er
 
 	nodes := make([]map[string]interface{}, 0)
 	for rows.Next() {
-		n := scanNodeRow(rows)
+		n := db.scanNodeRow(rows)
 		if n != nil {
 			nodes = append(nodes, n)
 		}
@@ -863,13 +890,17 @@ func (db *DB) SearchNodes(query string, limit int) ([]map[string]interface{}, er
 
 // GetNodeByPubkey returns a single node.
 func (db *DB) GetNodeByPubkey(pubkey string) (map[string]interface{}, error) {
-	rows, err := db.conn.Query("SELECT public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c FROM nodes WHERE public_key = ?", pubkey)
+	colList := "public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c"
+	if db.hasMultibyteSupCols {
+		colList += ", multibyte_sup, multibyte_evidence"
+	}
+	rows, err := db.conn.Query(fmt.Sprintf("SELECT %s FROM nodes WHERE public_key = ?", colList), pubkey)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	if rows.Next() {
-		return scanNodeRow(rows), nil
+		return db.scanNodeRow(rows), nil
 	}
 	return nil, nil
 }
@@ -1826,15 +1857,21 @@ func scanPacketRow(rows *sql.Rows) map[string]interface{} {
 	}
 }
 
-func scanNodeRow(rows *sql.Rows) map[string]interface{} {
+func (db *DB) scanNodeRow(rows *sql.Rows) map[string]interface{} {
 	var pk string
 	var name, role, lastSeen, firstSeen sql.NullString
 	var lat, lon sql.NullFloat64
 	var advertCount int
 	var batteryMv sql.NullInt64
 	var temperatureC sql.NullFloat64
+	var multibyteSup sql.NullInt64
+	var multibyteEvidence sql.NullString
 
-	if err := rows.Scan(&pk, &name, &role, &lat, &lon, &lastSeen, &firstSeen, &advertCount, &batteryMv, &temperatureC); err != nil {
+	scanArgs := []interface{}{&pk, &name, &role, &lat, &lon, &lastSeen, &firstSeen, &advertCount, &batteryMv, &temperatureC}
+	if db.hasMultibyteSupCols {
+		scanArgs = append(scanArgs, &multibyteSup, &multibyteEvidence)
+	}
+	if err := rows.Scan(scanArgs...); err != nil {
 		return nil
 	}
 	m := map[string]interface{}{
@@ -1849,6 +1886,12 @@ func scanNodeRow(rows *sql.Rows) map[string]interface{} {
 		"last_heard":             nullStr(lastSeen),
 		"hash_size":              nil,
 		"hash_size_inconsistent": false,
+		"multibyte_sup":          int(multibyteSup.Int64), // always present; zero-value when col absent
+	}
+	if multibyteEvidence.Valid {
+		m["multibyte_evidence"] = multibyteEvidence.String
+	} else {
+		m["multibyte_evidence"] = nil
 	}
 	if batteryMv.Valid {
 		m["battery_mv"] = int(batteryMv.Int64)

--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -125,6 +125,9 @@ func (db *DB) transmissionBaseSQL() (selectCols, observerJoin string) {
 				ORDER BY length(COALESCE(path_json,'')) DESC LIMIT 1
 			)`
 	}
+	if db.hasScopeName {
+		selectCols += `, t.scope_name`
+	}
 	return
 }
 
@@ -135,13 +138,18 @@ func (db *DB) scanTransmissionRow(rows *sql.Rows) map[string]interface{} {
 	var rawHex, hash, firstSeen, decodedJSON, observerID, observerName, pathJSON, direction sql.NullString
 	var routeType, payloadType sql.NullInt64
 	var snr, rssi sql.NullFloat64
+	var scopeName sql.NullString
 
-	if err := rows.Scan(&id, &rawHex, &hash, &firstSeen, &routeType, &payloadType, &decodedJSON,
-		&observationCount, &observerID, &observerName, &snr, &rssi, &pathJSON, &direction); err != nil {
+	scanArgs := []interface{}{&id, &rawHex, &hash, &firstSeen, &routeType, &payloadType, &decodedJSON,
+		&observationCount, &observerID, &observerName, &snr, &rssi, &pathJSON, &direction}
+	if db.hasScopeName {
+		scanArgs = append(scanArgs, &scopeName)
+	}
+	if err := rows.Scan(scanArgs...); err != nil {
 		return nil
 	}
 
-	return map[string]interface{}{
+	m := map[string]interface{}{
 		"id":                id,
 		"raw_hex":           nullStr(rawHex),
 		"hash":              nullStr(hash),
@@ -158,6 +166,10 @@ func (db *DB) scanTransmissionRow(rows *sql.Rows) map[string]interface{} {
 		"path_json":         nullStr(pathJSON),
 		"direction":         nullStr(direction),
 	}
+	if db.hasScopeName {
+		m["scope_name"] = nullStr(scopeName)
+	}
+	return m
 }
 
 // Node represents a row from the nodes table.

--- a/cmd/server/db_test.go
+++ b/cmd/server/db_test.go
@@ -2033,3 +2033,53 @@ func TestPerObservationRawHexEnrich(t *testing.T) {
 		}
 	}
 }
+
+func TestGetScopeStats(t *testing.T) {
+	conn, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	conn.SetMaxOpenConns(1)
+	db := &DB{conn: conn}
+	defer db.conn.Close()
+
+	// Create minimal schema
+	db.conn.Exec(`CREATE TABLE IF NOT EXISTS transmissions (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		raw_hex TEXT, hash TEXT, first_seen TEXT, route_type INTEGER,
+		payload_type INTEGER, payload_version INTEGER, decoded_json TEXT,
+		scope_name TEXT DEFAULT NULL
+	)`)
+	// Manually set hasScopeName since we bypassed the detector
+	db.hasScopeName = true
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	// Transport scoped, known region
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('a', ?, 0, '#belgium')`, now)
+	// Transport scoped, unknown
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('b', ?, 0, '')`, now)
+	// Transport unscoped (NULL)
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('c', ?, 0, NULL)`, now)
+	// Non-transport (should not count)
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('d', ?, 1, NULL)`, now)
+
+	stats, err := db.GetScopeStats("24h")
+	if err != nil {
+		t.Fatalf("GetScopeStats: %v", err)
+	}
+	if stats.Summary.TransportTotal != 3 {
+		t.Errorf("TransportTotal = %d, want 3", stats.Summary.TransportTotal)
+	}
+	if stats.Summary.Scoped != 2 {
+		t.Errorf("Scoped = %d, want 2", stats.Summary.Scoped)
+	}
+	if stats.Summary.Unscoped != 1 {
+		t.Errorf("Unscoped = %d, want 1", stats.Summary.Unscoped)
+	}
+	if stats.Summary.UnknownScope != 1 {
+		t.Errorf("UnknownScope = %d, want 1", stats.Summary.UnknownScope)
+	}
+	if len(stats.ByRegion) != 1 || stats.ByRegion[0].Name != "#belgium" || stats.ByRegion[0].Count != 1 {
+		t.Errorf("ByRegion = %+v, want [{#belgium 1}]", stats.ByRegion)
+	}
+}

--- a/cmd/server/db_test.go
+++ b/cmd/server/db_test.go
@@ -2083,3 +2083,31 @@ func TestGetScopeStats(t *testing.T) {
 		t.Errorf("ByRegion = %+v, want [{#belgium 1}]", stats.ByRegion)
 	}
 }
+
+func TestGetNodesReturnsMultibyteSupField(t *testing.T) {
+	conn, _ := sql.Open("sqlite", ":memory:")
+	conn.SetMaxOpenConns(1)
+	conn.Exec(`CREATE TABLE nodes (
+		public_key TEXT PRIMARY KEY, name TEXT, role TEXT,
+		lat REAL, lon REAL, last_seen TEXT, first_seen TEXT,
+		advert_count INTEGER DEFAULT 0, battery_mv INTEGER, temperature_c REAL,
+		multibyte_sup INTEGER NOT NULL DEFAULT 0, multibyte_evidence TEXT
+	)`)
+	conn.Exec(`INSERT INTO nodes (public_key, name, role, last_seen, first_seen)
+		VALUES ('aabb1122', 'TestRep', 'repeater', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`)
+	db := &DB{conn: conn, hasMultibyteSupCols: true}
+
+	nodes, _, _, err := db.GetNodes(10, 0, "", "", "", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) == 0 {
+		t.Fatal("expected 1 node")
+	}
+	if _, ok := nodes[0]["multibyte_sup"]; !ok {
+		t.Error("multibyte_sup missing from GetNodes response")
+	}
+	if nodes[0]["multibyte_sup"] != 0 {
+		t.Errorf("multibyte_sup = %v, want 0", nodes[0]["multibyte_sup"])
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -154,6 +154,9 @@ func main() {
 		log.Fatalf("[store] failed to load: %v", err)
 	}
 
+	// Warm the multibyte capability snapshot so node enrichment works immediately.
+	go store.GetAnalyticsHashSizes("")
+
 	// Initialize persisted neighbor graph
 	dbPath = database.path
 	if err := ensureNeighborEdgesTable(dbPath); err != nil {

--- a/cmd/server/multibyte_capability_test.go
+++ b/cmd/server/multibyte_capability_test.go
@@ -385,6 +385,127 @@ func TestMultiByteCapability_RoleColumnPopulated(t *testing.T) {
 	}
 }
 
+// setupCapabilityTestDBWithMultibyteCols returns a DB with multibyte columns.
+func setupCapabilityTestDBWithMultibyteCols(t *testing.T) *DB {
+	t.Helper()
+	db := setupCapabilityTestDB(t)
+	db.conn.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0`)
+	db.conn.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_evidence TEXT`)
+	db.hasMultibyteSupCols = true
+	return db
+}
+
+func TestPersistMultiByteCapability_Confirmed(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "confirmed", Evidence: "advert"},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	var evidence sql.NullString
+	db.conn.QueryRow("SELECT multibyte_sup, multibyte_evidence FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup, &evidence)
+
+	if sup != 2 {
+		t.Errorf("multibyte_sup = %d, want 2", sup)
+	}
+	if !evidence.Valid || evidence.String != "advert" {
+		t.Errorf("multibyte_evidence = %v, want 'advert'", evidence)
+	}
+}
+
+func TestPersistMultiByteCapability_Suspected(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "suspected", Evidence: "path"},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	db.conn.QueryRow("SELECT multibyte_sup FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup)
+
+	if sup != 1 {
+		t.Errorf("multibyte_sup = %d, want 1", sup)
+	}
+}
+
+func TestPersistMultiByteCapability_NoDowngrade(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen, multibyte_sup, multibyte_evidence) VALUES (?, ?, ?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1), 2, "advert")
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "suspected", Evidence: "path"},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	var evidence sql.NullString
+	db.conn.QueryRow("SELECT multibyte_sup, multibyte_evidence FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup, &evidence)
+
+	if sup != 2 {
+		t.Errorf("multibyte_sup = %d after downgrade attempt, want 2 (no downgrade)", sup)
+	}
+	if !evidence.Valid || evidence.String != "advert" {
+		t.Errorf("multibyte_evidence = %v after downgrade attempt, want 'advert'", evidence)
+	}
+}
+
+func TestPersistMultiByteCapability_UnknownSkipped(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "unknown", Evidence: ""},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	db.conn.QueryRow("SELECT multibyte_sup FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup)
+
+	if sup != 0 {
+		t.Errorf("multibyte_sup = %d after unknown entry, want 0 (unchanged)", sup)
+	}
+}
+
+func TestPersistMultiByteCapability_NoOpWhenColsMissing(t *testing.T) {
+	db := setupCapabilityTestDB(t) // no multibyte cols, hasMultibyteSupCols = false
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "confirmed", Evidence: "advert"},
+	}
+	// Must not panic or error when columns don't exist
+	store.persistMultiByteCapability(entries)
+}
+
 // TestMultiByteCapability_AdopterEvidenceTakesPrecedence tests that when
 // adopter data shows hashSize >= 2 but path evidence says "suspected",
 // the node is upgraded to "confirmed" (Bug 3, #754).

--- a/cmd/server/multibyte_capability_test.go
+++ b/cmd/server/multibyte_capability_test.go
@@ -447,6 +447,45 @@ func TestEnrichNodeWithMultibyte_ZeroEntryNoChange(t *testing.T) {
 	}
 }
 
+// TestMultiByteCapability_SuspectedGuard_OwnHashSize1 tests that a node
+// whose own adverts confirm hash_size=1 is NOT marked suspected, even when
+// its prefix appears as a hop in a multibyte packet (prefix collision).
+func TestMultiByteCapability_SuspectedGuard_OwnHashSize1(t *testing.T) {
+	db := setupCapabilityTestDB(t)
+	defer db.conn.Close()
+
+	// LegacyNode advertises hash_size=1 (old firmware).
+	// Its 1-byte prefix "aa" collides with a hop in a multibyte packet.
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "LegacyNode", "repeater", recentTS(24))
+
+	store := NewPacketStore(db, nil)
+
+	// Own advert: hash_size=1
+	addTestPacket(store, makeTestAdvert("aabbccdd11223344", 1))
+
+	// A multibyte packet (payload_type=1, path with 2-byte hop) whose hop
+	// prefix "aa" collides with LegacyNode's prefix.
+	pathByte := buildPathByte(2, 1)
+	rawHex := "01" + pathByte + "aa"
+	pt := 1
+	pkt := &StoreTx{
+		RawHex:      rawHex,
+		PayloadType: &pt,
+		PathJSON:    `["aa"]`,
+		FirstSeen:   recentTS(48),
+	}
+	addTestPacket(store, pkt)
+
+	caps := store.computeMultiByteCapability(nil)
+	if len(caps) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(caps))
+	}
+	if caps[0].Status != "unknown" {
+		t.Errorf("expected unknown (own advert confirms hash_size=1 — false positive guard), got %s", caps[0].Status)
+	}
+}
+
 // TestMultiByteCapability_AdopterEvidenceTakesPrecedence tests that when
 // adopter data shows hashSize >= 2 but path evidence says "suspected",
 // the node is upgraded to "confirmed" (Bug 3, #754).

--- a/cmd/server/multibyte_capability_test.go
+++ b/cmd/server/multibyte_capability_test.go
@@ -385,125 +385,66 @@ func TestMultiByteCapability_RoleColumnPopulated(t *testing.T) {
 	}
 }
 
-// setupCapabilityTestDBWithMultibyteCols returns a DB with multibyte columns.
-func setupCapabilityTestDBWithMultibyteCols(t *testing.T) *DB {
-	t.Helper()
+func TestGetMultibyteCapMap_Confirmed(t *testing.T) {
 	db := setupCapabilityTestDB(t)
-	db.conn.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0`)
-	db.conn.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_evidence TEXT`)
-	db.hasMultibyteSupCols = true
-	return db
-}
-
-func TestPersistMultiByteCapability_Confirmed(t *testing.T) {
-	db := setupCapabilityTestDBWithMultibyteCols(t)
 	defer db.conn.Close()
 
-	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
-		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
-
 	store := NewPacketStore(db, nil)
-	entries := []MultiByteCapEntry{
+	store.cacheMu.Lock()
+	store.mbCapSnapshot = []MultiByteCapEntry{
 		{PublicKey: "aabbccdd11223344", Status: "confirmed", Evidence: "advert"},
+		{PublicKey: "1122334455667788", Status: "suspected", Evidence: "path"},
 	}
-	store.persistMultiByteCapability(entries)
+	store.cacheMu.Unlock()
 
-	var sup int
-	var evidence sql.NullString
-	db.conn.QueryRow("SELECT multibyte_sup, multibyte_evidence FROM nodes WHERE public_key = ?",
-		"aabbccdd11223344").Scan(&sup, &evidence)
-
-	if sup != 2 {
-		t.Errorf("multibyte_sup = %d, want 2", sup)
+	m := store.GetMultibyteCapMap()
+	if e, ok := m["aabbccdd11223344"]; !ok || e.Status != "confirmed" || e.Evidence != "advert" {
+		t.Errorf("confirmed entry: got %+v, want confirmed/advert", e)
 	}
-	if !evidence.Valid || evidence.String != "advert" {
-		t.Errorf("multibyte_evidence = %v, want 'advert'", evidence)
+	if e, ok := m["1122334455667788"]; !ok || e.Status != "suspected" || e.Evidence != "path" {
+		t.Errorf("suspected entry: got %+v, want suspected/path", e)
 	}
 }
 
-func TestPersistMultiByteCapability_Suspected(t *testing.T) {
-	db := setupCapabilityTestDBWithMultibyteCols(t)
+func TestGetMultibyteCapMap_EmptyWhenNoSnapshot(t *testing.T) {
+	db := setupCapabilityTestDB(t)
 	defer db.conn.Close()
 
-	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
-		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
-
 	store := NewPacketStore(db, nil)
-	entries := []MultiByteCapEntry{
-		{PublicKey: "aabbccdd11223344", Status: "suspected", Evidence: "path"},
-	}
-	store.persistMultiByteCapability(entries)
-
-	var sup int
-	db.conn.QueryRow("SELECT multibyte_sup FROM nodes WHERE public_key = ?",
-		"aabbccdd11223344").Scan(&sup)
-
-	if sup != 1 {
-		t.Errorf("multibyte_sup = %d, want 1", sup)
+	m := store.GetMultibyteCapMap()
+	if len(m) != 0 {
+		t.Errorf("expected empty map before any analytics cycle, got %d entries", len(m))
 	}
 }
 
-func TestPersistMultiByteCapability_NoDowngrade(t *testing.T) {
-	db := setupCapabilityTestDBWithMultibyteCols(t)
-	defer db.conn.Close()
-
-	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen, multibyte_sup, multibyte_evidence) VALUES (?, ?, ?, ?, ?, ?)",
-		"aabbccdd11223344", "RepA", "repeater", recentTS(1), 2, "advert")
-
-	store := NewPacketStore(db, nil)
-	entries := []MultiByteCapEntry{
-		{PublicKey: "aabbccdd11223344", Status: "suspected", Evidence: "path"},
+func TestEnrichNodeWithMultibyte_Confirmed(t *testing.T) {
+	node := map[string]interface{}{"public_key": "aabb", "multibyte_sup": 0}
+	enrichNodeWithMultibyte(node, MultiByteCapEntry{Status: "confirmed", Evidence: "advert"})
+	if node["multibyte_sup"] != 2 {
+		t.Errorf("multibyte_sup = %v, want 2", node["multibyte_sup"])
 	}
-	store.persistMultiByteCapability(entries)
-
-	var sup int
-	var evidence sql.NullString
-	db.conn.QueryRow("SELECT multibyte_sup, multibyte_evidence FROM nodes WHERE public_key = ?",
-		"aabbccdd11223344").Scan(&sup, &evidence)
-
-	if sup != 2 {
-		t.Errorf("multibyte_sup = %d after downgrade attempt, want 2 (no downgrade)", sup)
-	}
-	if !evidence.Valid || evidence.String != "advert" {
-		t.Errorf("multibyte_evidence = %v after downgrade attempt, want 'advert'", evidence)
+	if node["multibyte_evidence"] != "advert" {
+		t.Errorf("multibyte_evidence = %v, want advert", node["multibyte_evidence"])
 	}
 }
 
-func TestPersistMultiByteCapability_UnknownSkipped(t *testing.T) {
-	db := setupCapabilityTestDBWithMultibyteCols(t)
-	defer db.conn.Close()
-
-	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
-		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
-
-	store := NewPacketStore(db, nil)
-	entries := []MultiByteCapEntry{
-		{PublicKey: "aabbccdd11223344", Status: "unknown", Evidence: ""},
-	}
-	store.persistMultiByteCapability(entries)
-
-	var sup int
-	db.conn.QueryRow("SELECT multibyte_sup FROM nodes WHERE public_key = ?",
-		"aabbccdd11223344").Scan(&sup)
-
-	if sup != 0 {
-		t.Errorf("multibyte_sup = %d after unknown entry, want 0 (unchanged)", sup)
+func TestEnrichNodeWithMultibyte_Suspected(t *testing.T) {
+	node := map[string]interface{}{"public_key": "aabb", "multibyte_sup": 0}
+	enrichNodeWithMultibyte(node, MultiByteCapEntry{Status: "suspected", Evidence: "path"})
+	if node["multibyte_sup"] != 1 {
+		t.Errorf("multibyte_sup = %v, want 1", node["multibyte_sup"])
 	}
 }
 
-func TestPersistMultiByteCapability_NoOpWhenColsMissing(t *testing.T) {
-	db := setupCapabilityTestDB(t) // no multibyte cols, hasMultibyteSupCols = false
-	defer db.conn.Close()
-
-	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
-		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
-
-	store := NewPacketStore(db, nil)
-	entries := []MultiByteCapEntry{
-		{PublicKey: "aabbccdd11223344", Status: "confirmed", Evidence: "advert"},
+func TestEnrichNodeWithMultibyte_ZeroEntryNoChange(t *testing.T) {
+	node := map[string]interface{}{"public_key": "aabb", "multibyte_sup": 0}
+	enrichNodeWithMultibyte(node, MultiByteCapEntry{}) // zero-value = unknown, no pubkey
+	if node["multibyte_sup"] != 0 {
+		t.Errorf("multibyte_sup = %v, want 0 (unchanged for unknown)", node["multibyte_sup"])
 	}
-	// Must not panic or error when columns don't exist
-	store.persistMultiByteCapability(entries)
+	if _, ok := node["multibyte_evidence"]; ok {
+		t.Error("multibyte_evidence should not be set for unknown entry")
+	}
 }
 
 // TestMultiByteCapability_AdopterEvidenceTakesPrecedence tests that when

--- a/cmd/server/multibyte_capability_test.go
+++ b/cmd/server/multibyte_capability_test.go
@@ -172,13 +172,13 @@ func TestMultiByteCapability_Unknown(t *testing.T) {
 }
 
 // TestMultiByteCapability_PrefixCollision tests that when two repeaters
-// share the same prefix, one confirmed via advert, the other gets
+// share the same 2-byte prefix, one confirmed via advert, the other gets
 // suspected (not confirmed) from path data alone.
 func TestMultiByteCapability_PrefixCollision(t *testing.T) {
 	db := setupCapabilityTestDB(t)
 	defer db.conn.Close()
 
-	// Two repeaters sharing 1-byte prefix "aa"
+	// Two repeaters sharing 2-byte prefix "aacc"
 	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
 		"aabb000000000001", "RepConfirmed", "repeater", recentTS(24))
 	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
@@ -189,14 +189,15 @@ func TestMultiByteCapability_PrefixCollision(t *testing.T) {
 	// RepConfirmed has a 2-byte advert
 	addTestPacket(store, makeTestAdvert("aabb000000000001", 2))
 
-	// A packet with 2-byte path containing 1-byte hop "aa" — both share this prefix
+	// A packet with hs=2 path containing 2-byte hop "aacc" — matches RepOther's
+	// 2-byte prefix. Hop length (2 bytes) correctly matches hash_size=2.
 	pathByte := buildPathByte(2, 1)
-	rawHex := "01" + pathByte + "aa"
+	rawHex := "01" + pathByte + "aacc"
 	pt := 1
 	pkt := &StoreTx{
 		RawHex:      rawHex,
 		PayloadType: &pt,
-		PathJSON:    `["aa"]`,
+		PathJSON:    `["aacc"]`,
 		FirstSeen:   recentTS(48),
 	}
 	addTestPacket(store, pkt)
@@ -444,6 +445,44 @@ func TestEnrichNodeWithMultibyte_ZeroEntryNoChange(t *testing.T) {
 	}
 	if _, ok := node["multibyte_evidence"]; ok {
 		t.Error("multibyte_evidence should not be set for unknown entry")
+	}
+}
+
+// TestMultiByteCapability_HopLengthMismatch tests that a 1-byte hop stored
+// in a hs=2 packet (pre-#886 ingestor data) does NOT trigger suspected.
+// The 1-byte prefix of a node must not match a malformed single-byte entry
+// from a path that was incorrectly split into individual bytes.
+func TestMultiByteCapability_HopLengthMismatch(t *testing.T) {
+	db := setupCapabilityTestDB(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"daabccdd11223344", "LegacyNode", "repeater", recentTS(24))
+
+	store := NewPacketStore(db, nil)
+
+	// Malformed packet: path_json has 1-byte hops but path_byte in raw_hex
+	// encodes hash_size=2 (pre-#886 ingestor stored path bytes individually).
+	// buildPathByte(2,1) gives a path byte with hs=2, hop_count=1.
+	pathByte := buildPathByte(2, 1)
+	// path_json has 1-byte hop "da" — matches 1-byte prefix of node "daab..."
+	// raw_hex says hash_size=2.
+	rawHex := "01" + pathByte + "da"
+	pt := 1
+	pkt := &StoreTx{
+		RawHex:      rawHex,
+		PayloadType: &pt,
+		PathJSON:    `["da"]`,
+		FirstSeen:   recentTS(48),
+	}
+	addTestPacket(store, pkt)
+
+	caps := store.computeMultiByteCapability(nil)
+	if len(caps) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(caps))
+	}
+	if caps[0].Status != "unknown" {
+		t.Errorf("expected unknown (hop length mismatch should be filtered), got %s", caps[0].Status)
 	}
 }
 

--- a/cmd/server/multibyte_capability_test.go
+++ b/cmd/server/multibyte_capability_test.go
@@ -447,45 +447,6 @@ func TestEnrichNodeWithMultibyte_ZeroEntryNoChange(t *testing.T) {
 	}
 }
 
-// TestMultiByteCapability_SuspectedGuard_OwnHashSize1 tests that a node
-// whose own adverts confirm hash_size=1 is NOT marked suspected, even when
-// its prefix appears as a hop in a multibyte packet (prefix collision).
-func TestMultiByteCapability_SuspectedGuard_OwnHashSize1(t *testing.T) {
-	db := setupCapabilityTestDB(t)
-	defer db.conn.Close()
-
-	// LegacyNode advertises hash_size=1 (old firmware).
-	// Its 1-byte prefix "aa" collides with a hop in a multibyte packet.
-	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
-		"aabbccdd11223344", "LegacyNode", "repeater", recentTS(24))
-
-	store := NewPacketStore(db, nil)
-
-	// Own advert: hash_size=1
-	addTestPacket(store, makeTestAdvert("aabbccdd11223344", 1))
-
-	// A multibyte packet (payload_type=1, path with 2-byte hop) whose hop
-	// prefix "aa" collides with LegacyNode's prefix.
-	pathByte := buildPathByte(2, 1)
-	rawHex := "01" + pathByte + "aa"
-	pt := 1
-	pkt := &StoreTx{
-		RawHex:      rawHex,
-		PayloadType: &pt,
-		PathJSON:    `["aa"]`,
-		FirstSeen:   recentTS(48),
-	}
-	addTestPacket(store, pkt)
-
-	caps := store.computeMultiByteCapability(nil)
-	if len(caps) != 1 {
-		t.Fatalf("expected 1 entry, got %d", len(caps))
-	}
-	if caps[0].Status != "unknown" {
-		t.Errorf("expected unknown (own advert confirms hash_size=1 — false positive guard), got %s", caps[0].Status)
-	}
-}
-
 // TestMultiByteCapability_AdopterEvidenceTakesPrecedence tests that when
 // adopter data shows hashSize >= 2 but path evidence says "suspected",
 // the node is upgraded to "confirmed" (Bug 3, #754).

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -1093,9 +1093,11 @@ func (s *Server) handleNodes(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.store != nil {
 		hashInfo := s.store.GetNodeHashSizeInfo()
+		mbCap := s.store.GetMultibyteCapMap()
 		for _, node := range nodes {
 			if pk, ok := node["public_key"].(string); ok {
 				EnrichNodeWithHashSize(node, hashInfo[pk])
+				enrichNodeWithMultibyte(node, mbCap[pk])
 			}
 		}
 	}
@@ -1162,6 +1164,7 @@ func (s *Server) handleNodeDetail(w http.ResponseWriter, r *http.Request) {
 	if s.store != nil {
 		hashInfo := s.store.GetNodeHashSizeInfo()
 		EnrichNodeWithHashSize(node, hashInfo[pubkey])
+		enrichNodeWithMultibyte(node, s.store.GetMultibyteCapMap()[pubkey])
 	}
 
 	name := ""
@@ -2270,6 +2273,22 @@ func (s *Server) handleAudioLabBuckets(w http.ResponseWriter, r *http.Request) {
 }
 
 // --- Helpers ---
+
+// enrichNodeWithMultibyte sets multibyte_sup and multibyte_evidence on a node map
+// from the in-memory analytics cache (avoids the need for DB writes from a ro connection).
+func enrichNodeWithMultibyte(node map[string]interface{}, e MultiByteCapEntry) {
+	sup := 0
+	switch e.Status {
+	case "confirmed":
+		sup = 2
+	case "suspected":
+		sup = 1
+	}
+	if sup > 0 {
+		node["multibyte_sup"] = sup
+		node["multibyte_evidence"] = e.Evidence
+	}
+}
 
 func writeJSON(w http.ResponseWriter, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -45,6 +45,11 @@ type Server struct {
 	neighborMu    sync.Mutex
 	neighborGraph *NeighborGraph
 
+	// Cached /api/scope-stats response — per-window, recomputed at most once every 30s
+	scopeStatsMu       sync.Mutex
+	scopeStatsCache    map[string]*ScopeStatsResponse
+	scopeStatsCachedAt map[string]time.Time
+
 	// Router reference for OpenAPI spec generation
 	router *mux.Router
 }
@@ -121,6 +126,7 @@ func (s *Server) RegisterRoutes(r *mux.Router) {
 	// System endpoints
 	r.HandleFunc("/api/health", s.handleHealth).Methods("GET")
 	r.HandleFunc("/api/stats", s.handleStats).Methods("GET")
+	r.HandleFunc("/api/scope-stats", s.handleScopeStats).Methods("GET")
 	r.HandleFunc("/api/perf", s.handlePerf).Methods("GET")
 	r.Handle("/api/perf/reset", s.requireAPIKey(http.HandlerFunc(s.handlePerfReset))).Methods("POST")
 	r.Handle("/api/admin/prune", s.requireAPIKey(http.HandlerFunc(s.handleAdminPrune))).Methods("POST")
@@ -2711,4 +2717,44 @@ func (s *Server) handleDroppedPackets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, results)
+}
+
+func (s *Server) handleScopeStats(w http.ResponseWriter, r *http.Request) {
+	const scopeStatsTTL = 30 * time.Second
+
+	window := r.URL.Query().Get("window")
+	if window == "" {
+		window = "24h"
+	}
+	if window != "1h" && window != "24h" && window != "7d" {
+		writeError(w, 400, "window must be 1h, 24h, or 7d")
+		return
+	}
+
+	s.scopeStatsMu.Lock()
+	if s.scopeStatsCache != nil {
+		if cached, ok := s.scopeStatsCache[window]; ok && time.Since(s.scopeStatsCachedAt[window]) < scopeStatsTTL {
+			s.scopeStatsMu.Unlock()
+			writeJSON(w, cached)
+			return
+		}
+	}
+	s.scopeStatsMu.Unlock()
+
+	resp, err := s.db.GetScopeStats(window)
+	if err != nil {
+		writeError(w, 500, err.Error())
+		return
+	}
+
+	s.scopeStatsMu.Lock()
+	if s.scopeStatsCache == nil {
+		s.scopeStatsCache = make(map[string]*ScopeStatsResponse)
+		s.scopeStatsCachedAt = make(map[string]time.Time)
+	}
+	s.scopeStatsCache[window] = resp
+	s.scopeStatsCachedAt[window] = time.Now()
+	s.scopeStatsMu.Unlock()
+
+	writeJSON(w, resp)
 }

--- a/cmd/server/routes_test.go
+++ b/cmd/server/routes_test.go
@@ -3972,3 +3972,34 @@ func TestPacketDetailPrefersStoreOverDB(t *testing.T) {
 		t.Errorf("expected observation_count=2 (from store), got %v", body["observation_count"])
 	}
 }
+
+func TestHandleScopeStats(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	// Add scope_name column and mark hasScopeName on the test DB
+	if _, err := srv.db.conn.Exec(`ALTER TABLE transmissions ADD COLUMN scope_name TEXT DEFAULT NULL`); err != nil {
+		t.Fatalf("add scope_name column: %v", err)
+	}
+	srv.db.hasScopeName = true
+
+	req := httptest.NewRequest("GET", "/api/scope-stats?window=24h", nil)
+	w := httptest.NewRecorder()
+	srv.handleScopeStats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	var resp ScopeStatsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Window != "24h" {
+		t.Errorf("window = %q, want 24h", resp.Window)
+	}
+	// TimeSeries and ByRegion are always non-nil slices
+	if resp.TimeSeries == nil {
+		t.Error("timeSeries is nil, want empty slice")
+	}
+	if resp.ByRegion == nil {
+		t.Error("byRegion is nil, want empty slice")
+	}
+}

--- a/cmd/server/routes_test.go
+++ b/cmd/server/routes_test.go
@@ -4003,3 +4003,32 @@ func TestHandleScopeStats(t *testing.T) {
 		t.Error("byRegion is nil, want empty slice")
 	}
 }
+
+func TestHandleScopeStatsInvalidWindow(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	if _, err := srv.db.conn.Exec(`ALTER TABLE transmissions ADD COLUMN scope_name TEXT DEFAULT NULL`); err != nil {
+		t.Fatalf("add scope_name column: %v", err)
+	}
+	srv.db.hasScopeName = true
+
+	req := httptest.NewRequest("GET", "/api/scope-stats?window=invalid", nil)
+	w := httptest.NewRecorder()
+	srv.handleScopeStats(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleScopeStatsNoColumn(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	// hasScopeName stays false (not set)
+
+	req := httptest.NewRequest("GET", "/api/scope-stats?window=24h", nil)
+	w := httptest.NewRecorder()
+	srv.handleScopeStats(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -141,6 +141,7 @@ type PacketStore struct {
 	rfCache      map[string]*cachedResult // region → cached RF result
 	topoCache    map[string]*cachedResult // region → cached topology result
 	hashCache      map[string]*cachedResult // region → cached hash-sizes result
+	mbCapSnapshot  []MultiByteCapEntry     // latest computeMultiByteCapability result, under cacheMu
 	collisionCache map[string]*cachedResult // cached hash-collisions result keyed by region ("" = global)
 	chanCache    map[string]*cachedResult // region → cached channels result
 	distCache    map[string]*cachedResult // region → cached distance result
@@ -5427,7 +5428,9 @@ func (s *PacketStore) GetAnalyticsHashSizes(region string) map[string]interface{
 		}
 		entries := s.computeMultiByteCapability(adopterHS)
 		result["multiByteCapability"] = entries
-		s.persistMultiByteCapability(entries)
+		s.cacheMu.Lock()
+		s.mbCapSnapshot = entries
+		s.cacheMu.Unlock()
 	}
 
 	s.cacheMu.Lock()
@@ -6332,29 +6335,17 @@ func (s *PacketStore) computeMultiByteCapability(adopterHashSizes map[string]int
 	return result
 }
 
-func (s *PacketStore) persistMultiByteCapability(entries []MultiByteCapEntry) {
-	if !s.db.hasMultibyteSupCols {
-		return
+// GetMultibyteCapMap returns a pubkey→entry snapshot from the last analytics cycle.
+// Used by routes to enrich node responses without a DB write (server conn is read-only).
+func (s *PacketStore) GetMultibyteCapMap() map[string]MultiByteCapEntry {
+	s.cacheMu.Lock()
+	snap := s.mbCapSnapshot
+	s.cacheMu.Unlock()
+	m := make(map[string]MultiByteCapEntry, len(snap))
+	for _, e := range snap {
+		m[e.PublicKey] = e
 	}
-	for _, e := range entries {
-		var sup int
-		switch e.Status {
-		case "confirmed":
-			sup = 2
-		case "suspected":
-			sup = 1
-		default:
-			continue
-		}
-		var evidence interface{}
-		if e.Evidence != "" {
-			evidence = e.Evidence
-		}
-		s.db.conn.Exec(
-			"UPDATE nodes SET multibyte_sup = ?, multibyte_evidence = ? WHERE public_key = ? AND multibyte_sup < ?",
-			sup, evidence, e.PublicKey, sup,
-		)
-	}
+	return m
 }
 
 // --- Bulk Health (in-memory) ---

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -6303,9 +6303,26 @@ func (s *PacketStore) computeMultiByteCapability(adopterHashSizes map[string]int
 			entry.Evidence = "advert"
 			entry.MaxHashSize = maxHS
 		} else if maxHS, ok := suspected[pk]; ok {
-			entry.Status = "suspected"
-			entry.Evidence = "path"
-			entry.MaxHashSize = maxHS
+			// Don't mark as suspected if node's own adverts confirm hash_size=1.
+			// A prefix collision with a multibyte hop is a false positive when the
+			// node has advertised and never used hash_size >= 2.
+			ownMax := 0
+			if info, hasInfo := hashInfo[pk]; hasInfo {
+				for sz := range info.AllSizes {
+					if sz > ownMax {
+						ownMax = sz
+					}
+				}
+			}
+			if ownMax == 0 || ownMax >= 2 {
+				// No own advert data (can't rule it out), or own adverts also show >=2
+				entry.Status = "suspected"
+				entry.Evidence = "path"
+				entry.MaxHashSize = maxHS
+			} else {
+				// Own adverts confirm hash_size=1 — prefix collision false positive
+				entry.Status = "unknown"
+			}
 		} else {
 			entry.Status = "unknown"
 		}

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -6303,26 +6303,9 @@ func (s *PacketStore) computeMultiByteCapability(adopterHashSizes map[string]int
 			entry.Evidence = "advert"
 			entry.MaxHashSize = maxHS
 		} else if maxHS, ok := suspected[pk]; ok {
-			// Don't mark as suspected if node's own adverts confirm hash_size=1.
-			// A prefix collision with a multibyte hop is a false positive when the
-			// node has advertised and never used hash_size >= 2.
-			ownMax := 0
-			if info, hasInfo := hashInfo[pk]; hasInfo {
-				for sz := range info.AllSizes {
-					if sz > ownMax {
-						ownMax = sz
-					}
-				}
-			}
-			if ownMax == 0 || ownMax >= 2 {
-				// No own advert data (can't rule it out), or own adverts also show >=2
-				entry.Status = "suspected"
-				entry.Evidence = "path"
-				entry.MaxHashSize = maxHS
-			} else {
-				// Own adverts confirm hash_size=1 — prefix collision false positive
-				entry.Status = "unknown"
-			}
+			entry.Status = "suspected"
+			entry.Evidence = "path"
+			entry.MaxHashSize = maxHS
 		} else {
 			entry.Status = "unknown"
 		}

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -6256,6 +6256,12 @@ func (s *PacketStore) computeMultiByteCapability(adopterHashSizes map[string]int
 			if hs < 2 {
 				continue
 			}
+			// Hop length must match hash_size. Pre-#886 ingestor data stored path
+			// bytes individually (1-byte entries) even for hs=2 packets, so a
+			// 1-byte prefix could match a malformed hop in a hs=2 packet.
+			if len(pfx)/2 != hs {
+				continue
+			}
 			// This packet uses multi-byte hashes and contains this prefix as a hop
 			for _, e := range entries {
 				if hs > suspected[e.pubkey] {

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -464,10 +464,19 @@ func (s *PacketStore) Load() error {
 		obsRawHexCol = ", o.raw_hex"
 	}
 
-	limitClause := ""
+	// Build WHERE conditions: retention cutoff (mirrors Evict logic) + optional memory-cap limit.
+	var loadConditions []string
+	if s.retentionHours > 0 {
+		cutoff := time.Now().UTC().Add(-time.Duration(s.retentionHours*3600) * time.Second).Format(time.RFC3339)
+		loadConditions = append(loadConditions, fmt.Sprintf("t.first_seen >= '%s'", cutoff))
+	}
 	if maxPackets > 0 {
-		limitClause = fmt.Sprintf(
-			"\n\t\t\tWHERE t.id IN (SELECT id FROM transmissions ORDER BY first_seen DESC LIMIT %d)", maxPackets)
+		loadConditions = append(loadConditions, fmt.Sprintf(
+			"t.id IN (SELECT id FROM transmissions ORDER BY first_seen DESC LIMIT %d)", maxPackets))
+	}
+	filterClause := ""
+	if len(loadConditions) > 0 {
+		filterClause = "\n\t\t\tWHERE " + strings.Join(loadConditions, "\n\t\t\t  AND ")
 	}
 
 	if s.db.isV3 {
@@ -477,7 +486,7 @@ func (s *PacketStore) Load() error {
 				o.snr, o.rssi, o.score, o.path_json, strftime('%Y-%m-%dT%H:%M:%fZ', o.timestamp, 'unixepoch')` + obsRawHexCol + rpCol + `
 			FROM transmissions t
 			LEFT JOIN observations o ON o.transmission_id = t.id
-			LEFT JOIN observers obs ON obs.rowid = o.observer_idx` + limitClause + `
+			LEFT JOIN observers obs ON obs.rowid = o.observer_idx` + filterClause + `
 			ORDER BY t.first_seen ASC, o.timestamp DESC`
 	} else {
 		loadSQL = `SELECT t.id, t.raw_hex, t.hash, t.first_seen, t.route_type,
@@ -485,7 +494,7 @@ func (s *PacketStore) Load() error {
 				o.id, o.observer_id, o.observer_name, o.direction,
 				o.snr, o.rssi, o.score, o.path_json, o.timestamp` + obsRawHexCol + rpCol + `
 			FROM transmissions t
-			LEFT JOIN observations o ON o.transmission_id = t.id` + limitClause + `
+			LEFT JOIN observations o ON o.transmission_id = t.id` + filterClause + `
 			ORDER BY t.first_seen ASC, o.timestamp DESC`
 	}
 

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -5416,7 +5416,9 @@ func (s *PacketStore) GetAnalyticsHashSizes(region string) map[string]interface{
 				}
 			}
 		}
-		result["multiByteCapability"] = s.computeMultiByteCapability(adopterHS)
+		entries := s.computeMultiByteCapability(adopterHS)
+		result["multiByteCapability"] = entries
+		s.persistMultiByteCapability(entries)
 	}
 
 	s.cacheMu.Lock()
@@ -6319,6 +6321,31 @@ func (s *PacketStore) computeMultiByteCapability(adopterHashSizes map[string]int
 	})
 
 	return result
+}
+
+func (s *PacketStore) persistMultiByteCapability(entries []MultiByteCapEntry) {
+	if !s.db.hasMultibyteSupCols {
+		return
+	}
+	for _, e := range entries {
+		var sup int
+		switch e.Status {
+		case "confirmed":
+			sup = 2
+		case "suspected":
+			sup = 1
+		default:
+			continue
+		}
+		var evidence interface{}
+		if e.Evidence != "" {
+			evidence = e.Evidence
+		}
+		s.db.conn.Exec(
+			"UPDATE nodes SET multibyte_sup = ?, multibyte_evidence = ? WHERE public_key = ? AND multibyte_sup < ?",
+			sup, evidence, e.PublicKey, sup,
+		)
+	}
 }
 
 // --- Bulk Health (in-memory) ---

--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -90,6 +90,33 @@ type StatsResponse struct {
 	GoSysMB       float64 `json:"goSysMB"`       // runtime.MemStats.Sys (total Go-managed)
 }
 
+// ─── Scope Stats ───────────────────────────────────────────────────────────────
+
+type ScopeStatsSummary struct {
+	TransportTotal int `json:"transportTotal"`
+	Scoped         int `json:"scoped"`
+	Unscoped       int `json:"unscoped"`
+	UnknownScope   int `json:"unknownScope"`
+}
+
+type ScopeRegionCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type ScopeTimePoint struct {
+	T        string `json:"t"`
+	Scoped   int    `json:"scoped"`
+	Unscoped int    `json:"unscoped"`
+}
+
+type ScopeStatsResponse struct {
+	Window     string             `json:"window"`
+	Summary    ScopeStatsSummary  `json:"summary"`
+	ByRegion   []ScopeRegionCount `json:"byRegion"`
+	TimeSeries []ScopeTimePoint   `json:"timeSeries"`
+}
+
 // ─── Health ────────────────────────────────────────────────────────────────────
 
 type MemoryStats struct {

--- a/config.example.json
+++ b/config.example.json
@@ -221,6 +221,11 @@
   "_comment_mqttSources": "Each source connects to an MQTT broker. topics: what to subscribe to. iataFilter: only ingest packets from these regions (optional).",
   "_comment_channelKeys": "Hex keys for decrypting channel messages. Key name = channel display name. public channel key is well-known.",
   "_comment_hashChannels": "Channel names whose keys are derived via SHA256. Key = SHA256(name)[:16]. Listed here so the ingestor can auto-derive keys.",
+  "hashRegions": [
+    "#belgium",
+    "#eu"
+  ],
+  "_comment_hashRegions": "Region names for scope matching on transport-route packets. Key = SHA256('#name')[:16]. Add any region names used by nodes in your network.",
   "_comment_defaultRegion": "IATA code shown by default in region filters.",
   "_comment_mapDefaults": "Initial map center [lat, lon] and zoom level.",
   "_comment_regions": "IATA code to display name mapping. Packets are tagged with region codes by MQTT topic structure."

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -309,7 +309,9 @@ Paginated node list with filtering.
       "hash_size":     number | null,    // latest hash size (1–3 bytes)
       "hash_size_inconsistent": boolean, // true if flip-flopping
       "hash_sizes_seen": [number] | undefined, // present only if >1 unique size seen
-      "last_heard":    string (ISO) | undefined // from in-memory packets or path relay
+      "last_heard":    string (ISO) | undefined, // from in-memory packets or path relay
+      "multibyte_sup": number,           // 0 = unknown, 1 = suspected, 2 = confirmed multibyte capability
+      "multibyte_evidence": string | null // "advert" | "path" | null
     }
   ],
   "total":  number,                      // total matching count (before pagination)
@@ -464,7 +466,9 @@ Node detail page data.
     "advert_count":  number,
     "hash_size":     number | null,
     "hash_size_inconsistent": boolean,
-    "hash_sizes_seen": [number] | undefined
+    "hash_sizes_seen": [number] | undefined,
+    "multibyte_sup": number,           // 0 = unknown, 1 = suspected, 2 = confirmed multibyte capability
+    "multibyte_evidence": string | null // "advert" | "path" | null
   },
   "recentAdverts": [Packet]   // last 20 packets for this node, newest first
 }

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -40,6 +40,7 @@
 - [GET /api/analytics/hash-sizes](#get-apianalyticshash-sizes)
 - [GET /api/analytics/subpaths](#get-apianalyticssubpaths)
 - [GET /api/analytics/subpath-detail](#get-apianalyticssubpath-detail)
+- [GET /api/scope-stats](#get-apiscope-stats)
 - [GET /api/resolve-hops](#get-apiresolve-hops)
 - [GET /api/traces/:hash](#get-apitraceshash)
 - [GET /api/config/theme](#get-apiconfigtheme)
@@ -1452,6 +1453,55 @@ Detailed stats for a specific subpath.
     { "name": string, "count": number }
   ]
 }
+```
+
+---
+
+## GET /api/scope-stats
+
+Scope-based packet statistics over a time window. Requires ingestor `scope_name_v1` migration to have run.
+
+### Query Parameters
+
+| Param    | Type   | Default | Description                                    |
+|----------|--------|---------|------------------------------------------------|
+| `window` | string | `24h`   | Time window: `1h`, `24h`, `7d`                |
+
+### Response `200`
+
+```jsonc
+{
+  "window":    string,               // echoed window ("1h", "24h", or "7d")
+  "summary": {
+    "transportTotal": number,        // scoped + unscoped transport-route packets
+    "scoped":         number,        // Code1 ≠ 0000 (named + unknown regions)
+    "unscoped":       number,        // transport-route with Code1 = 0000
+    "unknownScope":   number         // scoped but no configured region matched (subset of scoped)
+  },
+  "byRegion": [
+    { "name": string, "count": number }  // region name and packet count
+  ],
+  "timeSeries": [
+    { "t": string (ISO), "scoped": number, "unscoped": number }  // bucket timestamps and counts
+  ]
+}
+```
+
+**Notes:**
+- `transportTotal` = `scoped` + `unscoped` (only route_type 0 or 3 packets)
+- `scoped` = packets with Code1 ≠ 0000
+- `unscoped` = transport-route packets with Code1 = 0000
+- `unknownScope` = scoped packets that did not match any configured region name
+- Time-series bucket size depends on window:
+  - `1h` window → 5-minute buckets
+  - `24h` window → 1-hour buckets
+  - `7d` window → 6-hour buckets
+- Cached 30 seconds
+
+### Response `400`
+
+```json
+{ "error": "invalid window parameter" }
 ```
 
 ---

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1501,7 +1501,7 @@ Scope-based packet statistics over a time window. Requires ingestor `scope_name_
 ### Response `400`
 
 ```json
-{ "error": "invalid window parameter" }
+{ "error": "window must be 1h, 24h, or 7d" }
 ```
 
 ---

--- a/docs/superpowers/plans/2026-04-23-scope-stats.md
+++ b/docs/superpowers/plans/2026-04-23-scope-stats.md
@@ -1,0 +1,1358 @@
+# Scope Stats Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Scopes" tab to the Analytics page showing scoped vs non-scoped transport-route statistics with per-region breakdowns, driven by a `hashRegions` config list.
+
+**Architecture:** At ingest, each transport-route packet (route_type 0 or 3) with Code1 ≠ `0000` is matched against HMAC-SHA256 codes derived from configured region names — mirroring the `hashChannels`/`channel_hash` pattern. The matched name (or `""` for unknown) goes into a new `scope_name` column. The server exposes `/api/scope-stats?window=` which the Analytics "Scopes" tab calls for summary counts, a per-region table, and a two-line time-series chart.
+
+**Tech Stack:** Go (`crypto/hmac`, `crypto/sha256`), SQLite, vanilla JS (no new libraries)
+
+**Spec:** `docs/superpowers/specs/2026-04-23-scope-stats-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `cmd/ingestor/decoder.go` | Add `PayloadRaw []byte` to `DecodedPacket` |
+| `cmd/ingestor/decoder_test.go` | Test `PayloadRaw` is populated |
+| `cmd/ingestor/config.go` | Add `HashRegions []string` to `Config` |
+| `cmd/ingestor/main.go` | Add `loadRegionKeys`, `matchScope`, call backfill |
+| `cmd/ingestor/main_test.go` | Tests for `loadRegionKeys` and `matchScope` |
+| `cmd/ingestor/db.go` | Migration for `scope_name` column + `BackfillScopeNames` method |
+| `cmd/ingestor/db_test.go` | Test migration and backfill |
+| `cmd/server/db.go` | Add `hasScopeName` to schema detection + `GetScopeStats` |
+| `cmd/server/db_test.go` | Test `GetScopeStats` |
+| `cmd/server/types.go` | Add `ScopeStatsResponse` and sub-types |
+| `cmd/server/routes.go` | Add `handleScopeStats`, register route, add cache fields |
+| `public/analytics.js` | Add "Scopes" tab button + `renderScopesTab` function |
+| `public/index.html` | No change needed (tab is inside Analytics) |
+
+---
+
+## Task 1: Expose `PayloadRaw` in the decoder
+
+**Files:**
+- Modify: `cmd/ingestor/decoder.go` — `DecodedPacket` struct + `DecodePacket` function
+- Test: `cmd/ingestor/decoder_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cmd/ingestor/decoder_test.go`:
+
+```go
+func TestDecodePacketPayloadRaw(t *testing.T) {
+	// Build a minimal TRANSPORT_FLOOD packet (route_type=0):
+	// header(1) + transport_codes(4) + path_len(1) + payload(N)
+	// Header 0x00 = route_type=TRANSPORT_FLOOD, payload_type=0, version=0
+	// Code1=9A52, Code2=0000, path_len=0x00 (0 hops, hash_size=1)
+	payload := []byte("hello")
+	raw := []byte{0x00, 0x9A, 0x52, 0x00, 0x00, 0x00}
+	raw = append(raw, payload...)
+	hexStr := strings.ToUpper(hex.EncodeToString(raw))
+
+	decoded, err := DecodePacket(hexStr, nil, false)
+	if err != nil {
+		t.Fatalf("DecodePacket: %v", err)
+	}
+	if decoded.TransportCodes == nil {
+		t.Fatal("expected TransportCodes, got nil")
+	}
+	if string(decoded.PayloadRaw) != string(payload) {
+		t.Errorf("PayloadRaw = %v, want %v", decoded.PayloadRaw, payload)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```
+cd cmd/ingestor && go test -run TestDecodePacketPayloadRaw -v
+```
+Expected: compile error — `PayloadRaw` field does not exist on `DecodedPacket`.
+
+- [ ] **Step 3: Add `PayloadRaw` to `DecodedPacket`**
+
+In `cmd/ingestor/decoder.go`, find the `DecodedPacket` struct (around line 141) and add the field:
+
+```go
+type DecodedPacket struct {
+	Header         Header          `json:"header"`
+	TransportCodes *TransportCodes `json:"transportCodes"`
+	Path           Path            `json:"path"`
+	Payload        Payload         `json:"payload"`
+	Raw            string          `json:"raw"`
+	Anomaly        string          `json:"anomaly,omitempty"`
+	PayloadRaw     []byte          `json:"-"` // raw encrypted payload bytes, for HMAC matching
+}
+```
+
+Then in `DecodePacket` (around line 589), after `payloadBuf := buf[offset:]`, populate the field in the return statement (around line 635):
+
+```go
+return &DecodedPacket{
+	Header:         header,
+	TransportCodes: tc,
+	Path:           path,
+	Payload:        payload,
+	Raw:            strings.ToUpper(hexString),
+	Anomaly:        anomaly,
+	PayloadRaw:     payloadBuf,
+}, nil
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+cd cmd/ingestor && go test -run TestDecodePacketPayloadRaw -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Run all ingestor tests**
+
+```
+cd cmd/ingestor && go test ./... -v 2>&1 | tail -20
+```
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/ingestor/decoder.go cmd/ingestor/decoder_test.go
+git commit -m "feat(ingestor/decoder): expose PayloadRaw bytes on DecodedPacket (#899)"
+```
+
+---
+
+## Task 2: Config field + region key helpers
+
+**Files:**
+- Modify: `cmd/ingestor/config.go` — add `HashRegions []string`
+- Modify: `cmd/ingestor/main.go` — add `loadRegionKeys` and `matchScope`
+- Test: `cmd/ingestor/main_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `cmd/ingestor/main_test.go`:
+
+```go
+func TestLoadRegionKeys(t *testing.T) {
+	cfg := &Config{HashRegions: []string{"#belgium", "eu", "  #Test  ", "", "#belgium"}}
+	keys := loadRegionKeys(cfg)
+
+	// Deduplication + normalization
+	if len(keys) != 3 {
+		t.Fatalf("len(keys) = %d, want 3", len(keys))
+	}
+	// "#belgium" key = SHA256("#belgium")[:16]
+	h := sha256.Sum256([]byte("#belgium"))
+	want := h[:16]
+	if got := keys["#belgium"]; !bytes.Equal(got, want) {
+		t.Errorf("#belgium key mismatch: got %x, want %x", got, want)
+	}
+	// "eu" should be normalized to "#eu"
+	if _, ok := keys["#eu"]; !ok {
+		t.Error("expected #eu key")
+	}
+	// "  #Test  " should be normalized to "#Test"
+	if _, ok := keys["#Test"]; !ok {
+		t.Error("expected #Test key")
+	}
+}
+
+func TestMatchScope(t *testing.T) {
+	// Build a known Code1 for region "#test" and payload type 5, payload "hello"
+	name := "#test"
+	h := sha256.Sum256([]byte(name))
+	key := h[:16]
+
+	payloadType := byte(0x05)
+	payloadRaw := []byte("hello")
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte{payloadType})
+	mac.Write(payloadRaw)
+	hmacBytes := mac.Sum(nil)
+	code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+	if code == 0 {
+		code = 1
+	} else if code == 0xFFFF {
+		code = 0xFFFE
+	}
+	code1Bytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+	code1 := strings.ToUpper(hex.EncodeToString(code1Bytes[:]))
+
+	regionKeys := map[string][]byte{name: key}
+
+	got := matchScope(regionKeys, payloadType, payloadRaw, code1)
+	if got != name {
+		t.Errorf("matchScope = %q, want %q", got, name)
+	}
+
+	// Unscoped (Code1 = 0000) → empty
+	if got := matchScope(regionKeys, payloadType, payloadRaw, "0000"); got != "" {
+		t.Errorf("unscoped: matchScope = %q, want empty", got)
+	}
+
+	// Scoped but no match → empty string sentinel
+	if got := matchScope(regionKeys, payloadType, payloadRaw, "BEEF"); got != "" {
+		t.Errorf("no match: matchScope = %q, want empty", got)
+	}
+}
+```
+
+Also add the needed imports to the test file (`bytes`, `crypto/hmac`, `crypto/sha256`, `encoding/hex`, `strings`).
+
+- [ ] **Step 2: Run to verify they fail**
+
+```
+cd cmd/ingestor && go test -run "TestLoadRegionKeys|TestMatchScope" -v
+```
+Expected: compile error — `loadRegionKeys` and `matchScope` not defined.
+
+- [ ] **Step 3: Add `HashRegions` to Config**
+
+In `cmd/ingestor/config.go`, add the field after `HashChannels`:
+
+```go
+HashChannels    []string          `json:"hashChannels,omitempty"`
+HashRegions     []string          `json:"hashRegions,omitempty"`
+```
+
+- [ ] **Step 4: Add `loadRegionKeys` and `matchScope` to main.go**
+
+Add to `cmd/ingestor/main.go` (near `loadChannelKeys`, around line 755):
+
+```go
+// loadRegionKeys derives 16-byte HMAC keys from configured region names.
+// Key derivation matches firmware: SHA256("#regionname")[:16].
+// Names without a leading '#' are prefixed automatically.
+func loadRegionKeys(cfg *Config) map[string][]byte {
+	keys := make(map[string][]byte)
+	for _, raw := range cfg.HashRegions {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(name, "#") {
+			name = "#" + name
+		}
+		if _, exists := keys[name]; exists {
+			continue // deduplicate
+		}
+		h := sha256.Sum256([]byte(name))
+		keys[name] = h[:16]
+	}
+	if len(keys) > 0 {
+		log.Printf("[regions] %d region key(s) loaded", len(keys))
+	}
+	return keys
+}
+
+// matchScope tries each configured region key against Code1 using the same
+// HMAC derivation as the firmware (TransportKey::calcTransportCode).
+// Returns the matched region name, "" if scoped but no match, or "" if Code1 is "0000".
+func matchScope(regionKeys map[string][]byte, payloadType byte, payloadRaw []byte, code1 string) string {
+	if code1 == "0000" || len(regionKeys) == 0 || len(payloadRaw) == 0 {
+		return ""
+	}
+	for name, key := range regionKeys {
+		mac := hmac.New(sha256.New, key)
+		mac.Write([]byte{payloadType})
+		mac.Write(payloadRaw)
+		hmacBytes := mac.Sum(nil)
+		code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+		if code == 0 {
+			code = 1
+		} else if code == 0xFFFF {
+			code = 0xFFFE
+		}
+		codeBytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+		if strings.ToUpper(hex.EncodeToString(codeBytes[:])) == code1 {
+			return name
+		}
+	}
+	return "" // scoped but no configured region matched
+}
+```
+
+Add `"crypto/hmac"` to the imports in `main.go` (it already imports `crypto/sha256`).
+
+- [ ] **Step 5: Run tests**
+
+```
+cd cmd/ingestor && go test -run "TestLoadRegionKeys|TestMatchScope" -v
+```
+Expected: PASS
+
+- [ ] **Step 6: Run all ingestor tests**
+
+```
+cd cmd/ingestor && go test ./... 2>&1 | tail -10
+```
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/ingestor/config.go cmd/ingestor/main.go cmd/ingestor/main_test.go
+git commit -m "feat(ingestor): add hashRegions config + loadRegionKeys + matchScope (#899)"
+```
+
+---
+
+## Task 3: DB migration — `scope_name` column
+
+**Files:**
+- Modify: `cmd/ingestor/db.go` — migration block + `BackfillScopeNames`
+- Test: `cmd/ingestor/db_test.go` (or `main_test.go`)
+
+- [ ] **Step 1: Write the failing migration test**
+
+Add to `cmd/ingestor/db_test.go` (create the file if it doesn't exist, otherwise append):
+
+```go
+func TestScopeNameMigration(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	// Verify scope_name column exists
+	rows, err := store.db.Query("PRAGMA table_info(transmissions)")
+	if err != nil {
+		t.Fatalf("PRAGMA: %v", err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var cid int
+		var colName, colType string
+		var notNull, pk int
+		var dflt interface{}
+		if err := rows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk); err == nil {
+			if colName == "scope_name" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("scope_name column not found in transmissions")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```
+cd cmd/ingestor && go test -run TestScopeNameMigration -v
+```
+Expected: FAIL — scope_name column not found.
+
+- [ ] **Step 3: Add the migration to `cmd/ingestor/db.go`**
+
+Append after the last migration block (after the `observations_raw_hex_v1` block, before `return nil`):
+
+```go
+// Migration: add scope_name column for transport-route region matching (#899)
+row = db.QueryRow("SELECT 1 FROM _migrations WHERE name = 'scope_name_v1'")
+if row.Scan(&migDone) != nil {
+	log.Println("[migration] Adding scope_name column to transmissions...")
+	db.Exec(`ALTER TABLE transmissions ADD COLUMN scope_name TEXT DEFAULT NULL`)
+	db.Exec(`CREATE INDEX IF NOT EXISTS idx_tx_scope_name ON transmissions(scope_name) WHERE scope_name IS NOT NULL`)
+	db.Exec(`INSERT INTO _migrations (name) VALUES ('scope_name_v1')`)
+	log.Println("[migration] scope_name column added")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+cd cmd/ingestor && go test -run TestScopeNameMigration -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Add `BackfillScopeNames` to `cmd/ingestor/db.go`**
+
+Add this method to `Store` (near the bottom of db.go, before the closing brace):
+
+```go
+// BackfillScopeNames re-decodes raw_hex for existing transport-route rows
+// and populates scope_name using the given region keys.
+// Skips rows that already have scope_name set.
+// Safe to call with empty regionKeys — returns immediately.
+func (s *Store) BackfillScopeNames(regionKeys map[string][]byte) {
+	if len(regionKeys) == 0 {
+		return
+	}
+	rows, err := s.db.Query(`
+		SELECT id, raw_hex FROM transmissions
+		WHERE route_type IN (0, 3) AND scope_name IS NULL AND raw_hex IS NOT NULL
+	`)
+	if err != nil {
+		log.Printf("[backfill] scope_name query: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	type row struct {
+		id     int64
+		rawHex string
+	}
+	var pending []row
+	for rows.Next() {
+		var r row
+		if rows.Scan(&r.id, &r.rawHex) == nil && r.rawHex != "" {
+			pending = append(pending, r)
+		}
+	}
+
+	updated := 0
+	for _, r := range pending {
+		decoded, err := DecodePacket(r.rawHex, nil, false)
+		if err != nil || decoded.TransportCodes == nil {
+			continue
+		}
+		if decoded.TransportCodes.Code1 == "0000" {
+			continue // unscoped transport — leave NULL
+		}
+		scopeName := matchScope(regionKeys, byte(decoded.Header.PayloadType), decoded.PayloadRaw, decoded.TransportCodes.Code1)
+		// scopeName == "" means scoped but unknown — write empty string to distinguish from NULL
+		s.db.Exec(`UPDATE transmissions SET scope_name = ? WHERE id = ?`, scopeName, r.id)
+		updated++
+	}
+	if updated > 0 {
+		log.Printf("[backfill] scope_name set for %d/%d transport-route rows", updated, len(pending))
+	}
+}
+```
+
+- [ ] **Step 6: Add backfill test**
+
+Add to `cmd/ingestor/db_test.go`:
+
+```go
+func TestBackfillScopeNames(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenStore(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	defer store.Close()
+
+	// Insert a transport-route packet with known Code1
+	regionName := "#test"
+	h := sha256.Sum256([]byte(regionName))
+	key := h[:16]
+	payloadType := byte(0x05)
+	payloadRaw := []byte("hello")
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte{payloadType})
+	mac.Write(payloadRaw)
+	hmacBytes := mac.Sum(nil)
+	code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+	if code == 0 { code = 1 } else if code == 0xFFFF { code = 0xFFFE }
+	codeBytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+
+	// Build raw packet bytes: header(1) + Code1(2) + Code2(2) + path_len(1) + payload
+	header := byte(0x00) | (payloadType << 2) // TRANSPORT_FLOOD + payload_type in bits 2-5
+	raw := []byte{header}
+	raw = append(raw, codeBytes[:]...)
+	raw = append(raw, 0x00, 0x00) // Code2 = 0000
+	raw = append(raw, 0x00)       // path_len = 0 hops
+	raw = append(raw, payloadRaw...)
+	rawHex := strings.ToUpper(hex.EncodeToString(raw))
+
+	store.db.Exec(`INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, payload_version, decoded_json)
+		VALUES (?, 'testhash1', datetime('now'), 0, 5, 0, '{}')`, rawHex)
+
+	store.BackfillScopeNames(map[string][]byte{regionName: key})
+
+	var scopeName *string
+	store.db.QueryRow(`SELECT scope_name FROM transmissions WHERE hash = 'testhash1'`).Scan(&scopeName)
+	if scopeName == nil || *scopeName != regionName {
+		t.Errorf("scope_name = %v, want %q", scopeName, regionName)
+	}
+}
+```
+
+Add needed imports to db_test.go: `crypto/hmac`, `crypto/sha256`, `encoding/hex`, `strings`.
+
+- [ ] **Step 7: Run tests**
+
+```
+cd cmd/ingestor && go test -run "TestScopeNameMigration|TestBackfillScopeNames" -v
+```
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/ingestor/db.go cmd/ingestor/db_test.go
+git commit -m "feat(ingestor/db): add scope_name migration and BackfillScopeNames (#899)"
+```
+
+---
+
+## Task 4: Wire scope matching into ingest + backfill call
+
+**Files:**
+- Modify: `cmd/ingestor/db.go` — `PacketData` struct, `stmtInsertTransmission`, `InsertTransmission`
+- Modify: `cmd/ingestor/main.go` — `BuildPacketData` and startup call to `BackfillScopeNames`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `cmd/ingestor/main_test.go`:
+
+```go
+func TestBuildPacketDataScopeMatching(t *testing.T) {
+	// Build region key for "#test"
+	regionName := "#test"
+	h := sha256.Sum256([]byte(regionName))
+	key := h[:16]
+
+	payloadType := byte(0x05)
+	payloadRaw := []byte("hello")
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte{payloadType})
+	mac.Write(payloadRaw)
+	hmacBytes := mac.Sum(nil)
+	code := uint16(hmacBytes[0]) | uint16(hmacBytes[1])<<8
+	if code == 0 { code = 1 } else if code == 0xFFFF { code = 0xFFFE }
+	codeBytes := [2]byte{byte(code & 0xFF), byte(code >> 8)}
+
+	// TRANSPORT_FLOOD header with payloadType in bits 2-5
+	header := byte(0x00) | (payloadType << 2)
+	raw := []byte{header}
+	raw = append(raw, codeBytes[:]...)
+	raw = append(raw, 0x00, 0x00) // Code2
+	raw = append(raw, 0x00)       // path_len
+	raw = append(raw, payloadRaw...)
+	rawHex := strings.ToUpper(hex.EncodeToString(raw))
+
+	decoded, err := DecodePacket(rawHex, nil, false)
+	if err != nil {
+		t.Fatalf("DecodePacket: %v", err)
+	}
+
+	msg := &MQTTPacketMessage{Raw: rawHex}
+	regionKeys := map[string][]byte{regionName: key}
+
+	pktData := BuildPacketData(msg, decoded, "obs1", "region1", regionKeys)
+	if pktData.ScopeName != regionName {
+		t.Errorf("ScopeName = %q, want %q", pktData.ScopeName, regionName)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```
+cd cmd/ingestor && go test -run TestBuildPacketDataScopeMatching -v
+```
+Expected: compile error — `ScopeName` not on `PacketData`, `BuildPacketData` signature mismatch.
+
+- [ ] **Step 3: Add `ScopeName` to `PacketData`**
+
+In `cmd/ingestor/db.go`, in the `PacketData` struct (around line 908):
+
+```go
+type PacketData struct {
+	RawHex         string
+	Timestamp      string
+	ObserverID     string
+	ObserverName   string
+	SNR            *float64
+	RSSI           *float64
+	Score          *float64
+	Direction      *string
+	Hash           string
+	RouteType      int
+	PayloadType    int
+	PayloadVersion int
+	PathJSON       string
+	DecodedJSON    string
+	ChannelHash    string
+	ScopeName      string // "" = scoped but unknown; only set for transport routes with Code1≠0000
+}
+```
+
+- [ ] **Step 4: Update `stmtInsertTransmission` in `prepareStatements`**
+
+In `cmd/ingestor/db.go`, find `stmtInsertTransmission` prepare (around line 432) and update:
+
+```go
+s.stmtInsertTransmission, err = s.db.Prepare(`
+	INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, payload_version, decoded_json, channel_hash, scope_name)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`)
+```
+
+- [ ] **Step 5: Update `InsertTransmission` Exec call**
+
+In `cmd/ingestor/db.go`, find the `stmtInsertTransmission.Exec` call (around line 559) and add the `scope_name` argument:
+
+```go
+result, err := s.stmtInsertTransmission.Exec(
+	data.RawHex, hash, now,
+	data.RouteType, data.PayloadType, data.PayloadVersion,
+	data.DecodedJSON, nilIfEmpty(data.ChannelHash),
+	nilIfEmpty(data.ScopeName),
+)
+```
+
+Note: `nilIfEmpty` maps `""` → `nil` (SQL NULL). But the spec requires `""` (empty string) for "scoped but unknown". Use a different helper:
+
+Replace the last argument with:
+```go
+scopeNameVal,
+```
+
+And before the `Exec` call, add:
+```go
+var scopeNameVal interface{}
+if data.RouteType == 0 || data.RouteType == 3 {
+	// For transport routes, store the matched name (or "" for unknown scoped)
+	// Only leave NULL for non-transport routes
+	scopeNameVal = data.ScopeName // may be "" or "#regionname"
+	if data.ScopeName == "" && /* check Code1 == "0000": */ (decoded TransportCodes is nil check) {
+```
+
+Wait — `InsertTransmission` takes `*PacketData`, not the decoded packet. We don't have Code1 here. We need a different approach.
+
+Use a new convention: populate `ScopeName` in `BuildPacketData` as follows:
+- Non-transport route → `ScopeName = ""` with a sentinel meaning "not applicable" → store as NULL
+- Transport route + Code1 == "0000" → `ScopeName = ""` → store as NULL  
+- Transport route + Code1 ≠ "0000" + no match → `ScopeName = "\x00"` (internal sentinel for "scoped/unknown")
+- Transport route + Code1 ≠ "0000" + match → `ScopeName = "#regionname"`
+
+Actually, this is getting complicated. Simpler: add `IsTransportScoped bool` to `PacketData`:
+
+```go
+type PacketData struct {
+	// ... existing fields ...
+	ScopeName        string // matched region name, or "" 
+	IsTransportScoped bool  // true = transport route with Code1≠0000 (even if name unknown)
+}
+```
+
+Then in `InsertTransmission`:
+```go
+var scopeNameVal interface{}
+if data.IsTransportScoped {
+	scopeNameVal = data.ScopeName // "" or "#regionname" — both stored as non-NULL
+} // else: NULL (not a transport-scoped packet)
+```
+
+This cleanly encodes the three-state semantics without sentinels.
+
+- [ ] **Step 5 (revised): Update `PacketData`, `InsertTransmission`, `BuildPacketData`**
+
+In `cmd/ingestor/db.go`, `PacketData` struct:
+
+```go
+type PacketData struct {
+	RawHex           string
+	Timestamp        string
+	ObserverID       string
+	ObserverName     string
+	SNR              *float64
+	RSSI             *float64
+	Score            *float64
+	Direction        *string
+	Hash             string
+	RouteType        int
+	PayloadType      int
+	PayloadVersion   int
+	PathJSON         string
+	DecodedJSON      string
+	ChannelHash      string
+	ScopeName        string // matched region name, or "" for unknown-scoped
+	IsTransportScoped bool  // true when route_type IN (0,3) AND Code1 ≠ "0000"
+}
+```
+
+In `InsertTransmission` Exec call, replace `nilIfEmpty(data.ChannelHash),` line and add `scope_name`:
+
+```go
+result, err := s.stmtInsertTransmission.Exec(
+	data.RawHex, hash, now,
+	data.RouteType, data.PayloadType, data.PayloadVersion,
+	data.DecodedJSON, nilIfEmpty(data.ChannelHash),
+	scopeNameForDB(data),
+)
+```
+
+Add helper function in `db.go`:
+
+```go
+// scopeNameForDB converts PacketData scope fields to the DB value.
+// NULL = not a transport-scoped packet; "" = scoped but region unknown; "#name" = matched.
+func scopeNameForDB(data *PacketData) interface{} {
+	if !data.IsTransportScoped {
+		return nil
+	}
+	return data.ScopeName // "" or "#regionname"
+}
+```
+
+- [ ] **Step 6: Update `BuildPacketData` signature and body**
+
+In `cmd/ingestor/main.go`, find `BuildPacketData` (around line 948) and update signature:
+
+```go
+func BuildPacketData(msg *MQTTPacketMessage, decoded *DecodedPacket, observerID, region string, regionKeys map[string][]byte) *PacketData {
+```
+
+At the end of `BuildPacketData`, before the `return pd` line, add scope matching:
+
+```go
+// Scope matching for transport-route packets
+if decoded.TransportCodes != nil && decoded.TransportCodes.Code1 != "0000" {
+	pd.IsTransportScoped = true
+	pd.ScopeName = matchScope(regionKeys, byte(decoded.Header.PayloadType), decoded.PayloadRaw, decoded.TransportCodes.Code1)
+}
+```
+
+- [ ] **Step 7: Update both `BuildPacketData` call sites in `main.go`**
+
+Both calls (lines 354 and 377) become:
+
+```go
+pktData := BuildPacketData(mqttMsg, decoded, observerID, region, regionKeys)
+```
+
+`regionKeys` is loaded once at startup (see Step 9).
+
+- [ ] **Step 8: Load region keys at startup and call backfill**
+
+In `main()` in `cmd/ingestor/main.go`, after `loadChannelKeys` is called, add:
+
+```go
+regionKeys := loadRegionKeys(cfg)
+```
+
+Pass `regionKeys` to `BuildPacketData` where it's called (already done in Step 7).
+
+Also call backfill after the store is opened (find where `store` is initialized):
+
+```go
+go store.BackfillScopeNames(regionKeys)
+```
+
+Run in a goroutine so it doesn't block startup.
+
+- [ ] **Step 9: Run all ingestor tests**
+
+```
+cd cmd/ingestor && go test ./... 2>&1 | tail -20
+```
+Expected: all PASS (including `TestBuildPacketDataScopeMatching`)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add cmd/ingestor/db.go cmd/ingestor/main.go cmd/ingestor/main_test.go
+git commit -m "feat(ingestor): wire scope matching into ingest pipeline (#899)"
+```
+
+---
+
+## Task 5: Server — schema detection + `GetScopeStats`
+
+**Files:**
+- Modify: `cmd/server/db.go` — `detectSchema`, add `hasScopeName bool`, add `GetScopeStats`
+- Test: `cmd/server/db_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `cmd/server/db_test.go`:
+
+```go
+func TestGetScopeStats(t *testing.T) {
+	db, err := OpenDB(":memory:")
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer db.Close()
+
+	// Create minimal schema
+	db.conn.Exec(`CREATE TABLE IF NOT EXISTS transmissions (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		raw_hex TEXT, hash TEXT, first_seen TEXT, route_type INTEGER,
+		payload_type INTEGER, payload_version INTEGER, decoded_json TEXT,
+		scope_name TEXT DEFAULT NULL
+	)`)
+	// Manually set hasScopeName since we bypassed the detector
+	db.hasScopeName = true
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	// Transport scoped, known region
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('a', ?, 0, '#belgium')`, now)
+	// Transport scoped, unknown
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('b', ?, 0, '')`, now)
+	// Transport unscoped (NULL)
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('c', ?, 0, NULL)`, now)
+	// Non-transport (should not count)
+	db.conn.Exec(`INSERT INTO transmissions (hash, first_seen, route_type, scope_name) VALUES ('d', ?, 1, NULL)`, now)
+
+	stats, err := db.GetScopeStats("24h")
+	if err != nil {
+		t.Fatalf("GetScopeStats: %v", err)
+	}
+	if stats.Summary.TransportTotal != 3 {
+		t.Errorf("TransportTotal = %d, want 3", stats.Summary.TransportTotal)
+	}
+	if stats.Summary.Scoped != 2 {
+		t.Errorf("Scoped = %d, want 2", stats.Summary.Scoped)
+	}
+	if stats.Summary.Unscoped != 1 {
+		t.Errorf("Unscoped = %d, want 1", stats.Summary.Unscoped)
+	}
+	if stats.Summary.UnknownScope != 1 {
+		t.Errorf("UnknownScope = %d, want 1", stats.Summary.UnknownScope)
+	}
+	if len(stats.ByRegion) != 1 || stats.ByRegion[0].Name != "#belgium" || stats.ByRegion[0].Count != 1 {
+		t.Errorf("ByRegion = %+v, want [{#belgium 1}]", stats.ByRegion)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```
+cd cmd/server && go test -run TestGetScopeStats -v
+```
+Expected: compile error — `GetScopeStats` not defined, `hasScopeName` not a field.
+
+- [ ] **Step 3: Add `hasScopeName` to DB struct and `detectSchema`**
+
+In `cmd/server/db.go`, add to `DB` struct:
+
+```go
+type DB struct {
+	conn             *sql.DB
+	path             string
+	isV3             bool
+	hasResolvedPath  bool
+	hasObsRawHex     bool
+	hasScopeName     bool  // transmissions.scope_name column exists (#899)
+	// ... cache fields ...
+}
+```
+
+In `detectSchema`, in the loop that scans column names, add:
+
+```go
+if colName == "scope_name" {
+	db.hasScopeName = true
+}
+```
+
+- [ ] **Step 4: Add `ScopeStatsResponse` types to `cmd/server/types.go`**
+
+Add after the `StatsResponse` section:
+
+```go
+// ─── Scope Stats ───────────────────────────────────────────────────────────────
+
+type ScopeStatsSummary struct {
+	TransportTotal int `json:"transportTotal"`
+	Scoped         int `json:"scoped"`
+	Unscoped       int `json:"unscoped"`
+	UnknownScope   int `json:"unknownScope"`
+}
+
+type ScopeRegionCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type ScopeTimePoint struct {
+	T       string `json:"t"`
+	Scoped  int    `json:"scoped"`
+	Unscoped int   `json:"unscoped"`
+}
+
+type ScopeStatsResponse struct {
+	Window     string             `json:"window"`
+	Summary    ScopeStatsSummary  `json:"summary"`
+	ByRegion   []ScopeRegionCount `json:"byRegion"`
+	TimeSeries []ScopeTimePoint   `json:"timeSeries"`
+}
+```
+
+- [ ] **Step 5: Add `GetScopeStats` to `cmd/server/db.go`**
+
+Add at the end of db.go, before the closing line:
+
+```go
+// GetScopeStats returns scope statistics for the given window ("1h", "24h", "7d").
+func (db *DB) GetScopeStats(window string) (*ScopeStatsResponse, error) {
+	if !db.hasScopeName {
+		return nil, fmt.Errorf("scope_name column not present — run ingestor to apply migrations")
+	}
+
+	var since string
+	var bucketExpr string
+	switch window {
+	case "1h":
+		since = time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+		// 5-minute buckets
+		bucketExpr = `strftime('%Y-%m-%dT%H:', first_seen) || printf('%02d', (CAST(strftime('%M', first_seen) AS INTEGER) / 5) * 5) || ':00Z'`
+	case "7d":
+		since = time.Now().Add(-7 * 24 * time.Hour).UTC().Format(time.RFC3339)
+		// 6-hour buckets
+		bucketExpr = `strftime('%Y-%m-%dT', first_seen) || printf('%02d', (CAST(strftime('%H', first_seen) AS INTEGER) / 6) * 6) || ':00:00Z'`
+	default: // "24h"
+		window = "24h"
+		since = time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+		// 1-hour buckets
+		bucketExpr = `strftime('%Y-%m-%dT%H:00:00Z', first_seen)`
+	}
+
+	resp := &ScopeStatsResponse{Window: window}
+
+	// Summary counts
+	row := db.conn.QueryRow(`
+		SELECT
+			COUNT(*) AS transport_total,
+			COUNT(scope_name) AS scoped,
+			SUM(CASE WHEN scope_name IS NULL THEN 1 ELSE 0 END) AS unscoped,
+			SUM(CASE WHEN scope_name = '' THEN 1 ELSE 0 END) AS unknown_scope
+		FROM transmissions
+		WHERE route_type IN (0, 3) AND first_seen >= ?
+	`, since)
+	if err := row.Scan(
+		&resp.Summary.TransportTotal,
+		&resp.Summary.Scoped,
+		&resp.Summary.Unscoped,
+		&resp.Summary.UnknownScope,
+	); err != nil {
+		return nil, fmt.Errorf("scope summary query: %w", err)
+	}
+
+	// Per-region counts (named regions only)
+	rows, err := db.conn.Query(`
+		SELECT scope_name, COUNT(*) AS cnt
+		FROM transmissions
+		WHERE route_type IN (0, 3) AND scope_name IS NOT NULL AND scope_name != '' AND first_seen >= ?
+		GROUP BY scope_name
+		ORDER BY cnt DESC
+	`, since)
+	if err != nil {
+		return nil, fmt.Errorf("scope byRegion query: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rc ScopeRegionCount
+		if rows.Scan(&rc.Name, &rc.Count) == nil {
+			resp.ByRegion = append(resp.ByRegion, rc)
+		}
+	}
+	if resp.ByRegion == nil {
+		resp.ByRegion = []ScopeRegionCount{}
+	}
+
+	// Time series
+	tsQuery := fmt.Sprintf(`
+		SELECT %s AS bucket,
+			COUNT(scope_name) AS scoped,
+			SUM(CASE WHEN scope_name IS NULL THEN 1 ELSE 0 END) AS unscoped
+		FROM transmissions
+		WHERE route_type IN (0, 3) AND first_seen >= ?
+		GROUP BY bucket
+		ORDER BY bucket
+	`, bucketExpr)
+	tsRows, err := db.conn.Query(tsQuery, since)
+	if err != nil {
+		return nil, fmt.Errorf("scope timeseries query: %w", err)
+	}
+	defer tsRows.Close()
+	for tsRows.Next() {
+		var pt ScopeTimePoint
+		if tsRows.Scan(&pt.T, &pt.Scoped, &pt.Unscoped) == nil {
+			resp.TimeSeries = append(resp.TimeSeries, pt)
+		}
+	}
+	if resp.TimeSeries == nil {
+		resp.TimeSeries = []ScopeTimePoint{}
+	}
+
+	return resp, nil
+}
+```
+
+- [ ] **Step 6: Run test**
+
+```
+cd cmd/server && go test -run TestGetScopeStats -v
+```
+Expected: PASS
+
+- [ ] **Step 7: Run all server tests**
+
+```
+cd cmd/server && go test ./... 2>&1 | tail -20
+```
+Expected: all PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/server/db.go cmd/server/db_test.go cmd/server/types.go
+git commit -m "feat(server/db): add GetScopeStats and ScopeStatsResponse types (#899)"
+```
+
+---
+
+## Task 6: Server — HTTP handler + route registration
+
+**Files:**
+- Modify: `cmd/server/routes.go` — add cache fields to `Server`, register route, add `handleScopeStats`
+
+- [ ] **Step 1: Write failing handler test**
+
+Add to `cmd/server/routes_test.go`:
+
+```go
+func TestHandleScopeStats(t *testing.T) {
+	srv := newTestServer(t)
+	// Manually mark hasScopeName on the test DB
+	srv.db.hasScopeName = true
+
+	req := httptest.NewRequest("GET", "/api/scope-stats?window=24h", nil)
+	w := httptest.NewRecorder()
+	srv.handleScopeStats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp ScopeStatsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Window != "24h" {
+		t.Errorf("window = %q, want 24h", resp.Window)
+	}
+	// TimeSeries and ByRegion are always non-nil slices
+	if resp.TimeSeries == nil {
+		t.Error("timeSeries is nil, want empty slice")
+	}
+	if resp.ByRegion == nil {
+		t.Error("byRegion is nil, want empty slice")
+	}
+}
+```
+
+Check `routes_test.go` for how `newTestServer` is implemented and adapt if needed.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```
+cd cmd/server && go test -run TestHandleScopeStats -v
+```
+Expected: compile error — `handleScopeStats` not defined.
+
+- [ ] **Step 3: Add cache fields to `Server` struct**
+
+In `cmd/server/routes.go`, add to `Server` struct (near the other cache fields):
+
+```go
+// Scope stats cache (30s TTL)
+scopeStatsMu      sync.Mutex
+scopeStatsCache   map[string]*ScopeStatsResponse // keyed by window param
+scopeStatsCachedAt map[string]time.Time
+```
+
+- [ ] **Step 4: Register the route**
+
+In the route registration block in `cmd/server/routes.go` (near `/api/stats`):
+
+```go
+r.HandleFunc("/api/scope-stats", s.handleScopeStats).Methods("GET")
+```
+
+- [ ] **Step 5: Add `handleScopeStats`**
+
+Add to `cmd/server/routes.go`:
+
+```go
+func (s *Server) handleScopeStats(w http.ResponseWriter, r *http.Request) {
+	const scopeStatsTTL = 30 * time.Second
+
+	window := r.URL.Query().Get("window")
+	if window == "" {
+		window = "24h"
+	}
+	if window != "1h" && window != "24h" && window != "7d" {
+		writeError(w, 400, "window must be 1h, 24h, or 7d")
+		return
+	}
+
+	s.scopeStatsMu.Lock()
+	if s.scopeStatsCache != nil {
+		if cached, ok := s.scopeStatsCache[window]; ok && time.Since(s.scopeStatsCachedAt[window]) < scopeStatsTTL {
+			s.scopeStatsMu.Unlock()
+			writeJSON(w, cached)
+			return
+		}
+	}
+	s.scopeStatsMu.Unlock()
+
+	resp, err := s.db.GetScopeStats(window)
+	if err != nil {
+		writeError(w, 500, err.Error())
+		return
+	}
+
+	s.scopeStatsMu.Lock()
+	if s.scopeStatsCache == nil {
+		s.scopeStatsCache = make(map[string]*ScopeStatsResponse)
+		s.scopeStatsCachedAt = make(map[string]time.Time)
+	}
+	s.scopeStatsCache[window] = resp
+	s.scopeStatsCachedAt[window] = time.Now()
+	s.scopeStatsMu.Unlock()
+
+	writeJSON(w, resp)
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+```
+cd cmd/server && go test -run TestHandleScopeStats -v
+```
+Expected: PASS
+
+- [ ] **Step 7: Run all server tests**
+
+```
+cd cmd/server && go test ./... 2>&1 | tail -20
+```
+Expected: all PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/server/routes.go cmd/server/routes_test.go
+git commit -m "feat(server): add /api/scope-stats endpoint (#899)"
+```
+
+---
+
+## Task 7: Update API spec docs
+
+**Files:**
+- Modify: `docs/api-spec.md`
+
+- [ ] **Step 1: Add `GET /api/scope-stats` to `docs/api-spec.md`**
+
+Open `docs/api-spec.md` and add an entry for the new endpoint following the existing format. Include: method, path, query params (`window`: `1h`/`24h`/`7d`), response shape with the `ScopeStatsResponse` JSON, and a note that it requires the ingestor migration to have run.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/api-spec.md
+git commit -m "docs: add /api/scope-stats to api-spec (#899)"
+```
+
+---
+
+## Task 8: Frontend — "Scopes" tab in Analytics
+
+**Files:**
+- Modify: `public/analytics.js` — tab button + `renderScopesTab` function
+- Modify: `public/index.html` — bump `__BUST__` version for `analytics.js`
+
+- [ ] **Step 1: Add the tab button**
+
+In `public/analytics.js`, find the tab buttons list (around line 88). Add after `<button class="tab-btn" data-tab="prefix-tool">Prefix Tool</button>`:
+
+```html
+<button class="tab-btn" data-tab="scopes">Scopes</button>
+```
+
+- [ ] **Step 2: Wire the tab in `renderTab`**
+
+In `renderTab` (around line 186), add before the closing `}`:
+
+```js
+case 'scopes': await renderScopesTab(el); break;
+```
+
+- [ ] **Step 3: Add `renderScopesTab` function**
+
+Add just before the `registerPage('analytics', ...)` line at the end of `analytics.js`:
+
+```js
+// ===================== SCOPES =====================
+async function renderScopesTab(el) {
+  var window = 'scopes_window';
+  var selectedWindow = (typeof sessionStorage !== 'undefined' && sessionStorage.getItem(window)) || '24h';
+
+  async function load(w) {
+    el.innerHTML = '<div class="text-center text-muted" style="padding:40px">Loading scope stats…</div>';
+    try {
+      var data = await (await fetch('/api/scope-stats?window=' + encodeURIComponent(w))).json();
+      if (data.error) {
+        el.innerHTML = '<div class="text-center text-muted" style="padding:40px">' + esc(data.error) + '</div>';
+        return;
+      }
+      render(data, w);
+    } catch (err) {
+      el.innerHTML = '<div class="text-center" style="color:var(--status-red);padding:40px">Failed to load scope stats: ' + esc(String(err)) + '</div>';
+    }
+  }
+
+  function pct(n, total) {
+    if (!total) return '—';
+    return (n / total * 100).toFixed(1) + '%';
+  }
+
+  function render(d, w) {
+    var s = d.summary;
+    var total = s.transportTotal || 0;
+
+    // Window selector
+    var winHtml = ['1h', '24h', '7d'].map(function(v) {
+      return '<button class="tab-btn' + (w === v ? ' active' : '') + '" data-win="' + v + '">' + v + '</button>';
+    }).join('');
+
+    // Summary cards
+    var cardsHtml = [
+      { label: 'Transport Total', value: total.toLocaleString(), note: '' },
+      { label: 'Scoped', value: s.scoped.toLocaleString(), note: pct(s.scoped, total) },
+      { label: 'Unscoped', value: s.unscoped.toLocaleString(), note: pct(s.unscoped, total) },
+      { label: 'Unknown Scope', value: s.unknownScope.toLocaleString(), note: pct(s.unknownScope, s.scoped) + ' of scoped' },
+    ].map(function(c) {
+      return '<div class="stat-card"><div class="stat-value">' + c.value + '</div>' +
+        '<div class="stat-label">' + c.label + '</div>' +
+        (c.note ? '<div class="stat-note text-muted" style="font-size:11px">' + c.note + '</div>' : '') +
+        '</div>';
+    }).join('');
+
+    // Per-region table
+    var tableBody = '';
+    if (d.byRegion && d.byRegion.length) {
+      tableBody = d.byRegion.map(function(r) {
+        return '<tr><td><code>' + esc(r.name) + '</code></td>' +
+          '<td>' + r.count.toLocaleString() + '</td>' +
+          '<td>' + pct(r.count, s.scoped) + '</td></tr>';
+      }).join('');
+      if (s.unknownScope > 0) {
+        tableBody += '<tr><td><em class="text-muted">Unknown scope</em></td>' +
+          '<td>' + s.unknownScope.toLocaleString() + '</td>' +
+          '<td>' + pct(s.unknownScope, s.scoped) + '</td></tr>';
+      }
+    } else if (s.scoped === 0) {
+      tableBody = '<tr><td colspan="3" class="text-muted" style="text-align:center">No scoped messages in this window</td></tr>';
+    } else {
+      tableBody = '<tr><td colspan="3" class="text-muted" style="text-align:center">No regions configured — add <code>hashRegions</code> to your config</td></tr>';
+    }
+
+    // Time-series chart (two-line SVG)
+    var chartHtml = '';
+    if (d.timeSeries && d.timeSeries.length > 1) {
+      var scopedVals = d.timeSeries.map(function(p) { return p.scoped; });
+      var unscopedVals = d.timeSeries.map(function(p) { return p.unscoped; });
+      var maxVal = Math.max(1, Math.max.apply(null, scopedVals.concat(unscopedVals)));
+      var W = 800, H = 180, padL = 44, padB = 24, padT = 10, padR = 10;
+      var plotW = W - padL - padR, plotH = H - padB - padT;
+      var n = d.timeSeries.length;
+
+      function pts(vals) {
+        return vals.map(function(v, i) {
+          var x = padL + i * plotW / Math.max(n - 1, 1);
+          var y = padT + plotH - (v / maxVal) * plotH;
+          return x.toFixed(1) + ',' + y.toFixed(1);
+        }).join(' ');
+      }
+
+      // Grid lines
+      var grid = '';
+      for (var gi = 0; gi <= 4; gi++) {
+        var gy = padT + plotH * gi / 4;
+        var gv = Math.round(maxVal * (4 - gi) / 4);
+        grid += '<line x1="' + padL + '" y1="' + gy.toFixed(1) + '" x2="' + (W - padR) + '" y2="' + gy.toFixed(1) + '" stroke="var(--border)" stroke-dasharray="2"/>';
+        grid += '<text x="' + (padL - 4) + '" y="' + (gy + 4).toFixed(1) + '" text-anchor="end" font-size="9" fill="var(--text-muted)">' + gv + '</text>';
+      }
+
+      var legendX = padL + plotW - 120;
+      chartHtml = '<div style="margin-top:16px">' +
+        '<svg viewBox="0 0 ' + W + ' ' + H + '" style="width:100%;max-height:' + H + 'px" role="img" aria-label="Scope time series">' +
+        grid +
+        '<polyline points="' + pts(scopedVals) + '" fill="none" stroke="var(--accent)" stroke-width="2"/>' +
+        '<polyline points="' + pts(unscopedVals) + '" fill="none" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="4"/>' +
+        '<rect x="' + legendX + '" y="' + padT + '" width="10" height="10" fill="var(--accent)"/>' +
+        '<text x="' + (legendX + 14) + '" y="' + (padT + 9) + '" font-size="10" fill="var(--text)">Scoped</text>' +
+        '<rect x="' + legendX + '" y="' + (padT + 16) + '" width="10" height="10" fill="var(--text-muted)"/>' +
+        '<text x="' + (legendX + 14) + '" y="' + (padT + 25) + '" font-size="10" fill="var(--text)">Unscoped</text>' +
+        '</svg></div>';
+    }
+
+    el.innerHTML =
+      '<h3 style="margin:0 0 12px">🔭 Scope Statistics</h3>' +
+      '<div style="margin-bottom:12px">' + winHtml + '</div>' +
+      '<div class="stats-grid" style="margin-bottom:16px">' + cardsHtml + '</div>' +
+      '<table class="data-table analytics-table" style="margin-bottom:8px">' +
+      '<thead><tr><th>Region</th><th>Messages</th><th>% of Scoped</th></tr></thead>' +
+      '<tbody>' + tableBody + '</tbody></table>' +
+      chartHtml;
+
+    // Bind window selector
+    el.querySelectorAll('[data-win]').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        selectedWindow = btn.dataset.win;
+        if (typeof sessionStorage !== 'undefined') sessionStorage.setItem(window, selectedWindow);
+        load(selectedWindow);
+      });
+    });
+  }
+
+  load(selectedWindow);
+}
+```
+
+- [ ] **Step 4: Bump cache buster in `public/index.html`**
+
+Find the line that loads `analytics.js` with a `?v=__BUST__` suffix and increment the bust value to match the other files changed in this PR. Follow the project convention for how `__BUST__` is managed (check the existing values in the file and the Makefile/build script if any).
+
+- [ ] **Step 5: Manual smoke test**
+
+Start the server pointing at a DB that has had the ingestor migration run:
+```
+cd cmd/server && go run . -db path/to/meshcore.db
+```
+Open the browser at `http://localhost:8080/#/analytics?tab=scopes`. Verify:
+- The "Scopes" tab appears and is clickable
+- Summary cards render with counts (may be zeros on a fresh DB)
+- Window selector switches between 1h / 24h / 7d
+- No JS errors in the browser console
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/analytics.js public/index.html
+git commit -m "feat(frontend): add Scopes tab to Analytics page (#899)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: All items covered: Feature 1 (scoped/unscoped counts) ✅, Feature 2 (region matching via config) ✅, Feature 3 (excluded — firmware limitation) ✅ noted in spec
+- **NULL semantics**: `scopeNameForDB` correctly encodes the three states (NULL / "" / "#name")
+- **HMAC derivation**: `matchScope` mirrors firmware exactly — little-endian uint16, zero/FFFF adjustment, first 2 bytes of HMAC output
+- **API spec doc**: Task 7 updates `docs/api-spec.md` as required by project convention
+- **Cache buster**: Task 8 Step 4 bumps `analytics.js` bust value
+- **Backfill goroutine**: Runs in background so ingestor startup is not blocked
+- **Empty slices**: `GetScopeStats` always returns non-nil slices for `ByRegion` and `TimeSeries` to avoid `null` in JSON

--- a/docs/superpowers/plans/2026-04-25-multibyte-map-overlay.md
+++ b/docs/superpowers/plans/2026-04-25-multibyte-map-overlay.md
@@ -1,0 +1,788 @@
+# Multibyte Map Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a map overlay that colors repeater markers by multibyte-capability status (confirmed / suspected / unknown), backed by a persisted DB column populated from the server's existing analytics computation.
+
+**Architecture:** The ingestor adds `multibyte_sup` + `multibyte_evidence` columns to the `nodes` table via a migration. The server's `PacketStore.persistMultiByteCapability()` upserts results from the already-running `computeMultiByteCapability()` analytics cycle into those columns (no-downgrade guard). `/api/nodes` passes the columns through to the frontend, which applies marker coloring when the new toggle is enabled.
+
+**Tech Stack:** Go (server + ingestor), SQLite (shared DB), vanilla JS (map.js / Leaflet)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `cmd/ingestor/db.go` | Add `multibyte_sup_v1` migration (ALTER TABLE nodes + inactive_nodes) |
+| `cmd/ingestor/db_test.go` | Add schema test for new columns |
+| `cmd/server/db.go` | Add `hasMultibyteSupCols` flag, update `detectSchema()`, convert `scanNodeRow` to DB method with conditional scanning, update three SELECT queries |
+| `cmd/server/store.go` | Add `persistMultiByteCapability()`, wire into `GetHashSizes()` |
+| `cmd/server/multibyte_capability_test.go` | Add tests for `persistMultiByteCapability()` |
+| `public/map.js` | Add toggle to filters + UI, update `makeMarkerIcon` + `makeRepeaterLabelIcon` + `buildPopup` |
+
+---
+
+## Task 1: Ingestor migration — add multibyte_sup columns
+
+**Files:**
+- Modify: `cmd/ingestor/db.go` (after the `scope_name_v1` migration, around line 428)
+- Modify: `cmd/ingestor/db_test.go` (add test after `TestSchemaNoiseFloorIsReal`)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `cmd/ingestor/db_test.go` after the `TestSchemaNoiseFloorIsReal` function:
+
+```go
+func TestSchemaMultibyteSupColumns(t *testing.T) {
+	s, err := OpenStore(tempDBPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	cols := map[string]string{}
+	rows, err := s.db.Query("PRAGMA table_info(nodes)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var colName, colType string
+		var notNull, pk int
+		var dflt interface{}
+		if rows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk) == nil {
+			cols[colName] = colType
+		}
+	}
+
+	if ct, ok := cols["multibyte_sup"]; !ok {
+		t.Error("nodes.multibyte_sup column missing")
+	} else if ct != "INTEGER" {
+		t.Errorf("nodes.multibyte_sup type=%s, want INTEGER", ct)
+	}
+	if _, ok := cols["multibyte_evidence"]; !ok {
+		t.Error("nodes.multibyte_evidence column missing")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+cd cmd/ingestor && go test -run TestSchemaMultibyteSupColumns -v
+```
+
+Expected: FAIL — columns missing.
+
+- [ ] **Step 3: Add migration to `cmd/ingestor/db.go`**
+
+Locate the `scope_name_v1` migration block (around line 421). Add the following block immediately after it (after the closing `}`):
+
+```go
+// Migration: add multibyte capability columns to nodes/inactive_nodes (#903)
+row = db.QueryRow("SELECT 1 FROM _migrations WHERE name = 'multibyte_sup_v1'")
+if row.Scan(&migDone) != nil {
+    log.Println("[migration] Adding multibyte_sup columns to nodes/inactive_nodes...")
+    db.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0`)
+    db.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_evidence TEXT`)
+    db.Exec(`ALTER TABLE inactive_nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0`)
+    db.Exec(`ALTER TABLE inactive_nodes ADD COLUMN multibyte_evidence TEXT`)
+    db.Exec(`INSERT INTO _migrations (name) VALUES ('multibyte_sup_v1')`)
+    log.Println("[migration] multibyte_sup columns added")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+cd cmd/ingestor && go test -run TestSchemaMultibyteSupColumns -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full ingestor test suite**
+
+```
+cd cmd/ingestor && go test ./... 2>&1 | tail -5
+```
+
+Expected: `ok` with no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/ingestor/db.go cmd/ingestor/db_test.go
+git commit -m "feat(ingestor/db): add multibyte_sup migration to nodes table (#903)"
+```
+
+---
+
+## Task 2: Server schema detection + node row enrichment
+
+**Files:**
+- Modify: `cmd/server/db.go`
+
+The server opens the DB read-only and uses `detectSchema()` to discover columns. The `scanNodeRow` standalone function must become a method so it can check the `hasMultibyteSupCols` flag and conditionally scan.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `cmd/server/db_test.go`. Find an existing test that calls `GetNodes` and add a new one that asserts `multibyte_sup` is present in the returned map:
+
+```go
+func TestGetNodesReturnsMultibyteSupField(t *testing.T) {
+	conn, _ := sql.Open("sqlite", ":memory:")
+	conn.SetMaxOpenConns(1)
+	conn.Exec(`CREATE TABLE nodes (
+		public_key TEXT PRIMARY KEY, name TEXT, role TEXT,
+		lat REAL, lon REAL, last_seen TEXT, first_seen TEXT,
+		advert_count INTEGER DEFAULT 0, battery_mv INTEGER, temperature_c REAL,
+		multibyte_sup INTEGER NOT NULL DEFAULT 0, multibyte_evidence TEXT
+	)`)
+	conn.Exec(`INSERT INTO nodes (public_key, name, role, last_seen, first_seen)
+		VALUES ('aabb1122', 'TestRep', 'repeater', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`)
+	db := &DB{conn: conn, hasMultibyteSupCols: true}
+
+	nodes, _, _, err := db.GetNodes(10, 0, "", "", "", "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) == 0 {
+		t.Fatal("expected 1 node")
+	}
+	if _, ok := nodes[0]["multibyte_sup"]; !ok {
+		t.Error("multibyte_sup missing from GetNodes response")
+	}
+	if nodes[0]["multibyte_sup"] != 0 {
+		t.Errorf("multibyte_sup = %v, want 0", nodes[0]["multibyte_sup"])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+cd cmd/server && go test -run TestGetNodesReturnsMultibyteSupField -v
+```
+
+Expected: FAIL — `hasMultibyteSupCols` field doesn't exist yet.
+
+- [ ] **Step 3: Add `hasMultibyteSupCols` to `DB` struct**
+
+In `cmd/server/db.go`, add the field to the `DB` struct (around line 24):
+
+```go
+type DB struct {
+    conn             *sql.DB
+    path             string
+    isV3             bool
+    hasResolvedPath  bool
+    hasObsRawHex     bool
+    hasScopeName     bool
+    hasMultibyteSupCols bool // nodes.multibyte_sup column exists (#903)
+
+    channelsCacheMu  sync.Mutex
+    channelsCacheKey string
+    channelsCacheRes []map[string]interface{}
+    channelsCacheExp time.Time
+}
+```
+
+- [ ] **Step 4: Add nodes PRAGMA check to `detectSchema()`**
+
+In `cmd/server/db.go`, at the end of `detectSchema()` (after the `txRows` block that ends around line 103), add:
+
+```go
+nodeRows, err := db.conn.Query("PRAGMA table_info(nodes)")
+if err != nil {
+    return
+}
+defer nodeRows.Close()
+for nodeRows.Next() {
+    var cid int
+    var colName string
+    var colType sql.NullString
+    var notNull, pk int
+    var dflt sql.NullString
+    if nodeRows.Scan(&cid, &colName, &colType, &notNull, &dflt, &pk) == nil {
+        if colName == "multibyte_sup" {
+            db.hasMultibyteSupCols = true
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Convert `scanNodeRow` to a DB method with conditional scanning**
+
+Find `func scanNodeRow(rows *sql.Rows)` (around line 1829). Replace it entirely with:
+
+```go
+func (db *DB) scanNodeRow(rows *sql.Rows) map[string]interface{} {
+    var pk string
+    var name, role, lastSeen, firstSeen sql.NullString
+    var lat, lon sql.NullFloat64
+    var advertCount int
+    var batteryMv sql.NullInt64
+    var temperatureC sql.NullFloat64
+    var multibyteSup sql.NullInt64
+    var multibyteEvidence sql.NullString
+
+    scanArgs := []interface{}{&pk, &name, &role, &lat, &lon, &lastSeen, &firstSeen, &advertCount, &batteryMv, &temperatureC}
+    if db.hasMultibyteSupCols {
+        scanArgs = append(scanArgs, &multibyteSup, &multibyteEvidence)
+    }
+    if err := rows.Scan(scanArgs...); err != nil {
+        return nil
+    }
+    m := map[string]interface{}{
+        "public_key":             pk,
+        "name":                   nullStr(name),
+        "role":                   nullStr(role),
+        "lat":                    nullFloat(lat),
+        "lon":                    nullFloat(lon),
+        "last_seen":              nullStr(lastSeen),
+        "first_seen":             nullStr(firstSeen),
+        "advert_count":           advertCount,
+        "last_heard":             nullStr(lastSeen),
+        "hash_size":              nil,
+        "hash_size_inconsistent": false,
+        "multibyte_sup":          int(multibyteSup.Int64), // 0 when not scanned
+    }
+    if multibyteEvidence.Valid {
+        m["multibyte_evidence"] = multibyteEvidence.String
+    } else {
+        m["multibyte_evidence"] = nil
+    }
+    if batteryMv.Valid {
+        m["battery_mv"] = int(batteryMv.Int64)
+    } else {
+        m["battery_mv"] = nil
+    }
+    if temperatureC.Valid {
+        m["temperature_c"] = temperatureC.Float64
+    } else {
+        m["temperature_c"] = nil
+    }
+    return m
+}
+```
+
+- [ ] **Step 6: Update SELECT queries and call sites**
+
+In `cmd/server/db.go`, make three changes:
+
+**A. `GetNodes`** (around line 820) — replace the `querySQL` assignment:
+
+```go
+nodeColList := "public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c"
+if db.hasMultibyteSupCols {
+    nodeColList += ", multibyte_sup, multibyte_evidence"
+}
+querySQL := fmt.Sprintf("SELECT %s FROM nodes %s ORDER BY %s LIMIT ? OFFSET ?", nodeColList, w, order)
+```
+
+Then change `n := scanNodeRow(rows)` to `n := db.scanNodeRow(rows)`.
+
+**B. `SearchNodes`** (around line 846) — replace the `rows` query and call:
+
+```go
+colList := "public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c"
+if db.hasMultibyteSupCols {
+    colList += ", multibyte_sup, multibyte_evidence"
+}
+rows, err := db.conn.Query(
+    fmt.Sprintf("SELECT %s FROM nodes WHERE name LIKE ? OR public_key LIKE ? ORDER BY last_seen DESC LIMIT ?", colList),
+    "%"+query+"%", query+"%", limit)
+```
+
+Change `n := scanNodeRow(rows)` to `n := db.scanNodeRow(rows)`.
+
+**C. `GetNodeByPubkey`** (around line 866):
+
+```go
+colList := "public_key, name, role, lat, lon, last_seen, first_seen, advert_count, battery_mv, temperature_c"
+if db.hasMultibyteSupCols {
+    colList += ", multibyte_sup, multibyte_evidence"
+}
+rows, err := db.conn.Query(
+    fmt.Sprintf("SELECT %s FROM nodes WHERE public_key = ?", colList), pubkey)
+```
+
+Change `return scanNodeRow(rows), nil` to `return db.scanNodeRow(rows), nil`.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+```
+cd cmd/server && go test -run TestGetNodesReturnsMultibyteSupField -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run full server test suite**
+
+```
+cd cmd/server && go test ./... 2>&1 | tail -10
+```
+
+Expected: all pass. If `scanNodeRow` was referenced somewhere else as a standalone function, the compiler will catch it — fix those call sites to `db.scanNodeRow(rows)`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cmd/server/db.go cmd/server/db_test.go
+git commit -m "feat(server/db): expose multibyte_sup in node API response (#903)"
+```
+
+---
+
+## Task 3: persistMultiByteCapability + wire into analytics
+
+**Files:**
+- Modify: `cmd/server/store.go`
+- Modify: `cmd/server/multibyte_capability_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `cmd/server/multibyte_capability_test.go`:
+
+```go
+// setupCapabilityTestDBWithMultibyteCols returns a DB with multibyte columns.
+func setupCapabilityTestDBWithMultibyteCols(t *testing.T) *DB {
+	t.Helper()
+	db := setupCapabilityTestDB(t)
+	db.conn.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0`)
+	db.conn.Exec(`ALTER TABLE nodes ADD COLUMN multibyte_evidence TEXT`)
+	db.hasMultibyteSupCols = true
+	return db
+}
+
+func TestPersistMultiByteCapability_Confirmed(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "confirmed", Evidence: "advert"},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	var evidence sql.NullString
+	db.conn.QueryRow("SELECT multibyte_sup, multibyte_evidence FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup, &evidence)
+
+	if sup != 2 {
+		t.Errorf("multibyte_sup = %d, want 2", sup)
+	}
+	if !evidence.Valid || evidence.String != "advert" {
+		t.Errorf("multibyte_evidence = %v, want 'advert'", evidence)
+	}
+}
+
+func TestPersistMultiByteCapability_Suspected(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "suspected", Evidence: "path"},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	db.conn.QueryRow("SELECT multibyte_sup FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup)
+
+	if sup != 1 {
+		t.Errorf("multibyte_sup = %d, want 1", sup)
+	}
+}
+
+func TestPersistMultiByteCapability_NoDowngrade(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen, multibyte_sup, multibyte_evidence) VALUES (?, ?, ?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1), 2, "advert")
+
+	store := NewPacketStore(db, nil)
+	// Attempt to downgrade confirmed → suspected
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "suspected", Evidence: "path"},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	var evidence sql.NullString
+	db.conn.QueryRow("SELECT multibyte_sup, multibyte_evidence FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup, &evidence)
+
+	if sup != 2 {
+		t.Errorf("multibyte_sup = %d after downgrade attempt, want 2 (no downgrade)", sup)
+	}
+	if !evidence.Valid || evidence.String != "advert" {
+		t.Errorf("multibyte_evidence = %v after downgrade attempt, want 'advert'", evidence)
+	}
+}
+
+func TestPersistMultiByteCapability_UnknownSkipped(t *testing.T) {
+	db := setupCapabilityTestDBWithMultibyteCols(t)
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "unknown", Evidence: ""},
+	}
+	store.persistMultiByteCapability(entries)
+
+	var sup int
+	db.conn.QueryRow("SELECT multibyte_sup FROM nodes WHERE public_key = ?",
+		"aabbccdd11223344").Scan(&sup)
+
+	if sup != 0 {
+		t.Errorf("multibyte_sup = %d after unknown entry, want 0 (unchanged)", sup)
+	}
+}
+
+func TestPersistMultiByteCapability_NoOpWhenColsMissing(t *testing.T) {
+	db := setupCapabilityTestDB(t) // no multibyte cols, hasMultibyteSupCols = false
+	defer db.conn.Close()
+
+	db.conn.Exec("INSERT INTO nodes (public_key, name, role, last_seen) VALUES (?, ?, ?, ?)",
+		"aabbccdd11223344", "RepA", "repeater", recentTS(1))
+
+	store := NewPacketStore(db, nil)
+	entries := []MultiByteCapEntry{
+		{PublicKey: "aabbccdd11223344", Status: "confirmed", Evidence: "advert"},
+	}
+	// Must not panic or error when columns don't exist
+	store.persistMultiByteCapability(entries)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cd cmd/server && go test -run TestPersistMultiByteCapability -v
+```
+
+Expected: FAIL — `persistMultiByteCapability` undefined.
+
+- [ ] **Step 3: Add `persistMultiByteCapability` to `cmd/server/store.go`**
+
+Add the function directly after `computeMultiByteCapability` (after line 6322, before `// --- Bulk Health`):
+
+```go
+// persistMultiByteCapability upserts confirmed/suspected capability status into
+// the nodes table. Status only moves forward (0→1→2); confirmed is never
+// overwritten by suspected or unknown. Unknown entries are skipped entirely.
+// No-op when hasMultibyteSupCols is false (DB not yet migrated).
+func (s *PacketStore) persistMultiByteCapability(entries []MultiByteCapEntry) {
+    if !s.db.hasMultibyteSupCols {
+        return
+    }
+    for _, e := range entries {
+        var sup int
+        switch e.Status {
+        case "confirmed":
+            sup = 2
+        case "suspected":
+            sup = 1
+        default:
+            continue // unknown — nothing to write
+        }
+        var evidence interface{}
+        if e.Evidence != "" {
+            evidence = e.Evidence
+        }
+        s.db.conn.Exec(
+            "UPDATE nodes SET multibyte_sup = ?, multibyte_evidence = ? WHERE public_key = ? AND multibyte_sup < ?",
+            sup, evidence, e.PublicKey, sup,
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Wire into `GetHashSizes()` in `cmd/server/store.go`**
+
+Find the block around line 5419:
+
+```go
+result["multiByteCapability"] = s.computeMultiByteCapability(adopterHS)
+```
+
+Replace with:
+
+```go
+entries := s.computeMultiByteCapability(adopterHS)
+result["multiByteCapability"] = entries
+s.persistMultiByteCapability(entries)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cd cmd/server && go test -run TestPersistMultiByteCapability -v
+```
+
+Expected: all 5 PASS.
+
+- [ ] **Step 6: Run full server test suite**
+
+```
+cd cmd/server && go test ./... 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/server/store.go cmd/server/multibyte_capability_test.go
+git commit -m "feat(server): persist multibyte capability status to nodes table (#903)"
+```
+
+---
+
+## Task 4: Frontend — toggle + marker styling
+
+**Files:**
+- Modify: `public/map.js`
+
+- [ ] **Step 1: Add `multibyteOverlay` to filters state**
+
+In `public/map.js`, find the `filters` declaration (line 12). Add `multibyteOverlay` to it:
+
+```js
+let filters = { repeater: true, companion: true, room: true, sensor: true, observer: true, lastHeard: '30d', neighbors: false, clusters: false, hashLabels: localStorage.getItem('meshcore-map-hash-labels') !== 'false', statusFilter: localStorage.getItem('meshcore-map-status-filter') || 'all', byteSize: localStorage.getItem('meshcore-map-byte-filter') || 'all', multibyteOverlay: localStorage.getItem('meshcore-map-multibyte') === 'true' };
+```
+
+- [ ] **Step 2: Add checkbox to map controls HTML**
+
+In `public/map.js`, find the Byte Size fieldset (around line 114). Add the checkbox line immediately after the `</div>` that closes the `mcByteFilter` div (after line 121):
+
+```js
+          <fieldset class="mc-section">
+            <legend class="mc-label">Byte Size</legend>
+            <div class="filter-group" id="mcByteFilter">
+              <button class="btn ${filters.byteSize==='all'?'active':''}" data-byte="all">All</button>
+              <button class="btn ${filters.byteSize==='1'?'active':''}" data-byte="1">1-byte</button>
+              <button class="btn ${filters.byteSize==='2'?'active':''}" data-byte="2">2-byte</button>
+              <button class="btn ${filters.byteSize==='3'?'active':''}" data-byte="3">3-byte</button>
+            </div>
+            <label for="mcMultibyte" style="display:block;margin-top:6px;font-size:12px;cursor:pointer"><input type="checkbox" id="mcMultibyte" ${filters.multibyteOverlay?'checked':''}> Show multibyte capability</label>
+          </fieldset>
+```
+
+- [ ] **Step 3: Wire the change event listener**
+
+Find where the existing filter event listeners are registered (around line 285, near `mcLastHeard`). Add:
+
+```js
+document.getElementById('mcMultibyte').addEventListener('change', function(e) {
+  filters.multibyteOverlay = e.target.checked;
+  localStorage.setItem('meshcore-map-multibyte', e.target.checked);
+  renderMarkers();
+});
+```
+
+- [ ] **Step 4: Update `makeMarkerIcon` to accept and apply multibyte styling**
+
+In `public/map.js`, find `function makeMarkerIcon(role, isStale, isAlsoObserver)` (line 28). Replace it with:
+
+```js
+function makeMarkerIcon(role, isStale, isAlsoObserver, mbSup) {
+    const s = ROLE_STYLE[role] || ROLE_STYLE.companion;
+    const size = s.radius * 2 + 4;
+    const c = size / 2;
+
+    // Multibyte overlay color overrides (only when mbSup is a number, not null/undefined)
+    let fill = s.color;
+    let stroke = '#fff';
+    let strokeExtra = '';
+    let svgOpacity = 1;
+    if (mbSup !== null && mbSup !== undefined) {
+      if (mbSup >= 2) {
+        fill = '#22c55e'; stroke = '#16a34a';
+      } else if (mbSup >= 1) {
+        fill = '#86efac'; stroke = '#22c55e'; strokeExtra = ' stroke-dasharray="3,2"';
+      } else {
+        svgOpacity = 0.45;
+      }
+    }
+
+    let path;
+    switch (s.shape) {
+      case 'diamond':
+        path = `<polygon points="${c},2 ${size-2},${c} ${c},${size-2} 2,${c}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
+        break;
+      case 'square':
+        path = `<rect x="3" y="3" width="${size-6}" height="${size-6}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
+        break;
+      case 'triangle':
+        path = `<polygon points="${c},2 ${size-2},${size-2} 2,${size-2}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
+        break;
+      case 'star': {
+        const cx = c, cy = c, outer = c - 1, inner = outer * 0.4;
+        let pts = '';
+        for (let i = 0; i < 5; i++) {
+          const aOuter = (i * 72 - 90) * Math.PI / 180;
+          const aInner = ((i * 72) + 36 - 90) * Math.PI / 180;
+          pts += `${cx + outer * Math.cos(aOuter)},${cy + outer * Math.sin(aOuter)} `;
+          pts += `${cx + inner * Math.cos(aInner)},${cy + inner * Math.sin(aInner)} `;
+        }
+        path = `<polygon points="${pts.trim()}" fill="${fill}" stroke="${stroke}" stroke-width="1.5"${strokeExtra}/>`;
+        break;
+      }
+      default:
+        path = `<circle cx="${c}" cy="${c}" r="${c-2}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
+    }
+
+    let obsOverlay = '';
+    if (isAlsoObserver) {
+      const starSize = 8;
+      const sx = size - starSize, sy = 0;
+      const scx = starSize / 2, scy = starSize / 2, so = starSize / 2 - 0.5, si = so * 0.4;
+      let starPts = '';
+      for (let i = 0; i < 5; i++) {
+        const aO = (i * 72 - 90) * Math.PI / 180;
+        const aI = ((i * 72) + 36 - 90) * Math.PI / 180;
+        starPts += `${scx + so * Math.cos(aO)},${scy + so * Math.sin(aO)} `;
+        starPts += `${scx + si * Math.cos(aI)},${scy + si * Math.sin(aI)} `;
+      }
+      obsOverlay = `<g transform="translate(${sx},${sy})"><polygon points="${starPts.trim()}" fill="${ROLE_COLORS.observer || '#f1c40f'}" stroke="#fff" stroke-width="0.8"/></g>`;
+    }
+    const innerSvg = `${path}${obsOverlay}`;
+    const svg = svgOpacity < 1
+      ? `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg" opacity="${svgOpacity}">${innerSvg}</svg>`
+      : `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">${innerSvg}</svg>`;
+    return L.divIcon({
+      html: svg,
+      className: 'meshcore-marker' + (isStale ? ' marker-stale' : ''),
+      iconSize: [size, size],
+      iconAnchor: [c, c],
+      popupAnchor: [0, -c],
+    });
+  }
+```
+
+- [ ] **Step 5: Update `makeRepeaterLabelIcon` to accept and apply multibyte styling**
+
+In `public/map.js`, find `function makeRepeaterLabelIcon(node, isStale, isAlsoObserver)` (line 84). Replace with:
+
+```js
+  function makeRepeaterLabelIcon(node, isStale, isAlsoObserver, mbSup) {
+    var s = ROLE_STYLE['repeater'] || ROLE_STYLE.companion;
+    var hs = node.hash_size || 1;
+    var shortHash = node.public_key ? node.public_key.slice(0, hs * 2).toUpperCase() : '??';
+
+    var bgColor = s.color;
+    var textColor = '#fff';
+    var border = '2px solid #fff';
+    var extraStyle = '';
+    if (mbSup !== null && mbSup !== undefined) {
+      if (mbSup >= 2) {
+        bgColor = '#22c55e'; border = '2px solid #16a34a';
+      } else if (mbSup >= 1) {
+        bgColor = '#86efac'; textColor = '#14532d'; border = '2px dashed #22c55e';
+      } else {
+        extraStyle = 'opacity:0.45;';
+      }
+    }
+
+    var obsIndicator = isAlsoObserver ? ' <span style="color:' + (ROLE_COLORS.observer || '#f1c40f') + ';font-size:13px;line-height:1;" title="Also an observer">★</span>' : '';
+    var html = '<div style="background:' + bgColor + ';color:' + textColor + ';font-weight:bold;font-size:11px;padding:2px 5px;border-radius:3px;border:' + border + ';box-shadow:0 1px 3px rgba(0,0,0,0.4);text-align:center;line-height:1.2;white-space:nowrap;' + extraStyle + '">' +
+      shortHash + obsIndicator + '</div>';
+    return L.divIcon({
+      html: html,
+      className: 'meshcore-marker meshcore-label-marker' + (isStale ? ' marker-stale' : ''),
+      iconSize: null,
+      iconAnchor: [14, 12],
+      popupAnchor: [0, -12],
+    });
+  }
+```
+
+- [ ] **Step 6: Pass `mbSup` to icon functions at the marker creation call site**
+
+In `public/map.js`, find the marker creation loop (around line 808). Replace the icon creation line (line 814):
+
+```js
+      const mbSup = (filters.multibyteOverlay && node.role === 'repeater')
+        ? (typeof node.multibyte_sup === 'number' ? node.multibyte_sup : 0)
+        : null;
+      const icon = useLabel ? makeRepeaterLabelIcon(node, isStale, isAlsoObserver, mbSup) : makeMarkerIcon(node.role || 'companion', isStale, isAlsoObserver, mbSup);
+```
+
+- [ ] **Step 7: Add multibyte row to `buildPopup`**
+
+In `public/map.js`, find `function buildPopup(node)` (line 938). After the `hashPrefixRow` definition (after line 949), add:
+
+```js
+    const mbSup = typeof node.multibyte_sup === 'number' ? node.multibyte_sup : 0;
+    const mbEvidence = node.multibyte_evidence || null;
+    const mbLabel = mbSup >= 2 ? 'confirmed (advert)' : mbSup >= 1 ? 'suspected (path)' : 'not detected';
+    const mbColor = mbSup >= 2 ? '#22c55e' : mbSup >= 1 ? '#86efac' : '#9ca3af';
+    const mbRow = (filters.multibyteOverlay && node.role === 'repeater')
+      ? `<dt style="color:var(--text-muted);float:left;clear:left;width:80px;padding:2px 0;">Multibyte</dt>
+          <dd style="color:${mbColor};margin-left:88px;padding:2px 0;">${safeEsc(mbLabel)}</dd>`
+      : '';
+```
+
+Then in the `return` template, add `${mbRow}` after `${hashPrefixRow}`:
+
+```js
+        <dl style="margin-top:8px;font-size:12px;">
+          ${hashPrefixRow}
+          ${mbRow}
+          <dt ...>Key</dt>
+          ...
+```
+
+- [ ] **Step 8: Verify no JS errors in browser**
+
+Start the dev server and open the map page. Check browser console for errors. Toggle "Show multibyte capability" on and off. Confirm:
+- Toggle state persists on page reload
+- Repeater markers change color when toggle is ON
+- Non-repeater nodes are unaffected
+- Popup shows "Multibyte" row only when toggle is ON and node is a repeater
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add public/map.js
+git commit -m "feat(frontend): add multibyte capability overlay to map (#903)"
+```
+
+---
+
+## Task 5: Update API spec
+
+**Files:**
+- Modify: `docs/api-spec.md`
+
+- [ ] **Step 1: Add new fields to the `/api/nodes` response schema**
+
+Find the `GET /api/nodes` section in `docs/api-spec.md`. In the node object properties, add:
+
+```markdown
+| `multibyte_sup` | integer | `0` = unknown, `1` = suspected, `2` = confirmed multibyte capability |
+| `multibyte_evidence` | string \| null | `"advert"` (confirmed via advert), `"path"` (suspected via hop path), or `null` |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/api-spec.md
+git commit -m "docs(api-spec): add multibyte_sup and multibyte_evidence to node response (#903)"
+```

--- a/docs/superpowers/specs/2026-04-23-scope-stats-design.md
+++ b/docs/superpowers/specs/2026-04-23-scope-stats-design.md
@@ -1,0 +1,204 @@
+# Scope Stats Page — Design Spec
+
+**Issue**: Kpa-clawbot/CoreScope#899  
+**Date**: 2026-04-23  
+**Branch target**: `master`
+
+---
+
+## Overview
+
+Add a dedicated **Scopes** page showing scope/region statistics for MeshCore transport-route packets. Scope filtering in MeshCore uses `TRANSPORT_FLOOD` (route_type 0) and `TRANSPORT_DIRECT` (route_type 3) packets that carry two 16-bit transport codes. Code1 ≠ `0000` means the packet is region-scoped.
+
+Feature 3 from the issue (default scope per client via advert) is **not implemented** — the advert format has no scope field in the current firmware.
+
+---
+
+## How Scopes Work (Firmware)
+
+Transport code derivation (authoritative source: `meshcore-dev/MeshCore`):
+
+```
+key  = SHA256("#regionname")[:16]          // TransportKeyStore::getAutoKeyFor
+Code1 = HMAC-SHA256(key, type || payload)  // TransportKey::calcTransportCode, 2-byte output
+```
+
+Code1 is a **per-message** HMAC — the same region produces a different Code1 for every message. Identifying a region from Code1 requires knowing the region name in advance and recomputing the HMAC.
+
+`Code1 = 0000` is the "no scope" sentinel (also `FFFF` is reserved). Packets with route_type 1 or 2 (plain FLOOD/DIRECT) carry no transport codes.
+
+---
+
+## Config
+
+Add `hashRegions` to the ingestor `Config` struct in `cmd/ingestor/config.go`, mirroring `hashChannels`:
+
+```json
+"hashRegions": ["#belgium", "#eu", "#brussels"]
+```
+
+Normalization (same rules as `hashChannels`):
+- Trim whitespace
+- Prepend `#` if missing
+- Skip empty entries
+
+---
+
+## Ingestor Changes
+
+### Key derivation (`loadRegionKeys`)
+
+```go
+func loadRegionKeys(cfg *Config) map[string][]byte {
+    // key = first 16 bytes of SHA256("#regionname")
+}
+```
+
+Returns `map[string][]byte` (region name → 16-byte HMAC key). Called once at startup, stored on the `Store`.
+
+### Decoder: expose raw payload bytes
+
+Add `PayloadRaw []byte` to `DecodedPacket` in `cmd/ingestor/decoder.go`. Populated from the raw `buf` slice at the payload offset — zero-copy slice, no allocation. This is the **encrypted** payload bytes, matching what the firmware feeds into `calcTransportCode`.
+
+### At-ingest region matching
+
+In `BuildPacketData`:
+- Skip if `route_type` not in `{0, 3}` → `scope_name` stays `nil`
+- If `Code1 == "0000"` → `scope_name = nil` (unscoped transport, no scope involvement)
+- If `Code1 != "0000"` → try each region key:
+  ```
+  HMAC-SHA256(key, payloadType_byte || PayloadRaw)  → first 2 bytes as uint16
+  ```
+  First match → `scope_name = "#regionname"`. No match → `scope_name = ""` (unknown scope).
+
+Add `ScopeName *string` to `PacketData`.
+
+### MQTT-sourced packets (DM / CHAN paths in main.go)
+
+These are injected directly without going through `BuildPacketData`. They use `route_type = 1` (FLOOD), so they are never transport-route packets. No scope matching needed for these paths.
+
+---
+
+## Database
+
+### Migration
+
+```sql
+ALTER TABLE transmissions ADD COLUMN scope_name TEXT DEFAULT NULL;
+CREATE INDEX idx_tx_scope_name ON transmissions(scope_name) WHERE scope_name IS NOT NULL;
+```
+
+### Column semantics
+
+| Value | Meaning |
+|-------|---------|
+| `NULL` | Either: non-transport-route packet (route_type 1/2), or transport-route with Code1=0000 |
+| `""` (empty string) | Transport-route, Code1 ≠ 0000, but no configured region matched |
+| `"#belgium"` | Matched named region |
+
+The API stats queries resolve the NULL ambiguity by always filtering `route_type IN (0, 3)` first:
+- `unscoped` count = `route_type IN (0,3) AND scope_name IS NULL`
+- `scoped` count = `route_type IN (0,3) AND scope_name IS NOT NULL`
+
+### Backfill
+
+On migration, re-decode `raw_hex` for all rows where `route_type IN (0, 3)` and `scope_name IS NULL`. Run the same HMAC matching logic. Rows with `Code1 = 0000` remain `NULL`.
+
+The backfill runs in the existing migration framework in `cmd/ingestor/db.go`. If no regions are configured, backfill is skipped.
+
+---
+
+## API
+
+### `GET /api/scope-stats`
+
+**Query param**: `window` — one of `1h`, `24h` (default), `7d`
+
+**Time-series bucket sizes**:
+| Window | Bucket |
+|--------|--------|
+| `1h`   | 5 min  |
+| `24h`  | 1 hour |
+| `7d`   | 6 hours|
+
+**Response**:
+```json
+{
+  "window": "24h",
+  "summary": {
+    "transportTotal": 1240,
+    "scoped": 890,
+    "unscoped": 350,
+    "unknownScope": 42
+  },
+  "byRegion": [
+    { "name": "#belgium", "count": 612 },
+    { "name": "#eu",      "count": 236 }
+  ],
+  "timeSeries": [
+    { "t": "2026-04-23T10:00:00Z", "scoped": 45, "unscoped": 18 },
+    { "t": "2026-04-23T11:00:00Z", "scoped": 51, "unscoped": 22 }
+  ]
+}
+```
+
+- `transportTotal` = `scoped + unscoped` (transport-route packets only)
+- `scoped` = Code1 ≠ 0000 (named + unknown)
+- `unscoped` = transport-route with Code1 = 0000
+- `unknownScope` = scoped but no region name matched (subset of `scoped`)
+- `byRegion` sorted by count descending, excludes unknown
+- `timeSeries` covers the full window at the bucket granularity
+
+Route: `GET /api/scope-stats` registered in `cmd/server/routes.go`.  
+No auth required (same as other read endpoints).  
+TTL cache: 30 seconds (heavier query than `/api/stats`).
+
+---
+
+## Frontend
+
+### Navigation
+
+Add nav link between Channels and Nodes in `public/index.html`:
+```html
+<a href="#/scopes" class="nav-link" data-route="scopes">Scopes</a>
+```
+
+### `public/scopes.js`
+
+Three sections on the page:
+
+**1. Summary cards** (reuse existing card CSS pattern from home/analytics pages)  
+- Transport total, Scoped, Unscoped, Unknown scope  
+- Each card shows count + percentage of transport total
+
+**2. Per-region table**  
+Columns: Region, Messages, % of Scoped  
+Sorted by count descending. Last row: "Unknown scope" (italic) if unknownScope > 0.  
+Shows "No regions configured" message if `byRegion` is empty and `unknownScope = 0`.
+
+**3. Time-series chart**  
+- Window selector: `1h / 24h / 7d` (default 24h)  
+- Two lines: **Scoped** (blue) and **Unscoped** (grey)  
+- Uses the same lightweight canvas chart pattern as other pages (no external chart lib)
+
+### Cache buster
+
+`scopes.js` added to the `__BUST__` entries in `index.html` in the same commit.
+
+---
+
+## Testing
+
+- Unit tests for `loadRegionKeys`: normalization, key bytes match firmware SHA256 derivation
+- Unit tests for HMAC matching: known Code1 value computed from firmware logic, verified against Go implementation
+- Integration test: ingest a synthetic transport-route packet with a known region, assert `scope_name` column is set correctly
+- API test: `GET /api/scope-stats` returns correct summary counts against fixture DB
+
+---
+
+## Out of Scope
+
+- Feature 3 (default scope per client via advert) — firmware has no advert scope field
+- Drill-down from region row to filtered packet list (deferred)
+- Private regions (`$`-prefixed) — use secret keys not publicly derivable

--- a/docs/superpowers/specs/2026-04-23-scope-stats-design.md
+++ b/docs/superpowers/specs/2026-04-23-scope-stats-design.md
@@ -157,34 +157,27 @@ TTL cache: 30 seconds (heavier query than `/api/stats`).
 
 ## Frontend
 
-### Navigation
+### Placement
 
-Add nav link between Channels and Nodes in `public/index.html`:
-```html
-<a href="#/scopes" class="nav-link" data-route="scopes">Scopes</a>
-```
+Add a **"Scopes" tab** to the existing Analytics page (`public/analytics.js`) — no new nav item, no new JS file. Tab button added after the existing "Clock Health" tab in the `analyticsTabs` div.
 
-### `public/scopes.js`
+Deep-link: `#/analytics?tab=scopes`
 
-Three sections on the page:
+### Tab content — three sections
 
-**1. Summary cards** (reuse existing card CSS pattern from home/analytics pages)  
+**1. Summary cards** (reuse existing Analytics card CSS)  
 - Transport total, Scoped, Unscoped, Unknown scope  
 - Each card shows count + percentage of transport total
 
 **2. Per-region table**  
 Columns: Region, Messages, % of Scoped  
-Sorted by count descending. Last row: "Unknown scope" (italic) if unknownScope > 0.  
-Shows "No regions configured" message if `byRegion` is empty and `unknownScope = 0`.
+Sorted by count descending. Last row: "Unknown scope" (italic) if `unknownScope > 0`.  
+Shows a "No regions configured — add `hashRegions` to your config" hint if `byRegion` is empty and `unknownScope = 0`.
 
 **3. Time-series chart**  
 - Window selector: `1h / 24h / 7d` (default 24h)  
 - Two lines: **Scoped** (blue) and **Unscoped** (grey)  
-- Uses the same lightweight canvas chart pattern as other pages (no external chart lib)
-
-### Cache buster
-
-`scopes.js` added to the `__BUST__` entries in `index.html` in the same commit.
+- Uses the same inline SVG chart helpers already present in `analytics.js` (no external lib)
 
 ---
 

--- a/docs/superpowers/specs/2026-04-25-multibyte-map-overlay-design.md
+++ b/docs/superpowers/specs/2026-04-25-multibyte-map-overlay-design.md
@@ -1,0 +1,143 @@
+# Multibyte Capability Map Overlay — Design Spec
+
+**Issue:** [#903](https://github.com/Kpa-clawbot/CoreScope/issues/903)
+**Date:** 2026-04-25
+
+## Overview
+
+Add a toggle to the map controls that overlays multibyte-capability status on repeater markers. When active, markers are colored by evidence: confirmed (solid green), suspected (light green dashed), or unknown (dimmed gray). Status is derived from existing server-side capability analysis and persisted to the database so no startup scan is needed.
+
+---
+
+## Data Layer
+
+### Migration
+
+Two new columns on the `nodes` table:
+
+```sql
+ALTER TABLE nodes ADD COLUMN multibyte_sup INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE nodes ADD COLUMN multibyte_evidence TEXT;
+```
+
+**`multibyte_sup`** tri-state:
+
+| Value | Meaning |
+|---|---|
+| `0` | Unknown — no evidence seen |
+| `1` | Suspected — node prefix appeared as a hop in a multibyte-path packet |
+| `2` | Confirmed — node sent a multibyte advert (hash_size ≥ 2) directly |
+
+**`multibyte_evidence`**: informational string — `"advert"`, `"path"`, or `NULL`.
+
+### Write-back rule
+
+Status only moves forward, never backward:
+
+```sql
+UPDATE nodes
+SET multibyte_sup = ?, multibyte_evidence = ?
+WHERE public_key = ? AND multibyte_sup < ?
+```
+
+A confirmed node (`2`) is never overwritten by suspected (`1`) or unknown (`0`). Rows already at the target level are skipped entirely by the `< ?` guard, so write-back quickly becomes a no-op for stable networks.
+
+---
+
+## Server
+
+### Write-back function
+
+New function in `store.go`:
+
+```go
+func (s *Store) persistMultiByteCapability(entries []MultiByteCapEntry) error
+```
+
+Called at the end of the existing `computeMultiByteCapability()` analytics flow, after the in-memory result is cached. Executes one `UPDATE` per node that needs upgrading. Because this runs on the existing ~15 s analytics cache cycle and the eligible set shrinks over time, it stays cheap.
+
+`computeMultiByteCapability()` already distinguishes:
+- **Confirmed** (`evidence = "advert"`) — node's own advert had hash_size ≥ 2
+- **Suspected** (`evidence = "path"`) — node prefix appeared as a hop in a multibyte-path packet (TRACE packets excluded to avoid false positives)
+
+Both map to `multibyte_sup` values 2 and 1 respectively.
+
+### Node enrichment
+
+Two fields added to every node object in the `/api/nodes` response:
+- `multibyte_sup` — integer 0/1/2 (read from DB column, zero value if column absent)
+- `multibyte_evidence` — `"advert"` / `"path"` / `null`
+
+No new API endpoint. The columns are already fetched as part of the existing `nodes` row query — pass them through in `EnrichNodeWithHashSize` or alongside it.
+
+### No changes to:
+- Ingestor or packet ingestion path
+- Existing analytics endpoints
+- Any existing node DB writes
+
+---
+
+## Frontend
+
+### State
+
+```js
+filters = {
+  ...,
+  multibyteOverlay: localStorage.getItem('meshcore-map-multibyte') === 'true'
+}
+```
+
+Persisted in `localStorage`, same pattern as `byteSize` and `hashLabels`.
+
+### Toggle placement
+
+Added under the existing **Byte Size** `<fieldset>` in the map controls panel:
+
+```html
+<fieldset class="mc-section">
+  <legend class="mc-label">Byte Size</legend>
+  <div class="filter-group" id="mcByteFilter">
+    <!-- existing All / 1-byte / 2-byte / 3-byte buttons -->
+  </div>
+  <label for="mcMultibyte">
+    <input type="checkbox" id="mcMultibyte"> Show multibyte capability
+  </label>
+</fieldset>
+```
+
+### Marker styling
+
+Applied in the existing marker render path, only when `filters.multibyteOverlay === true`, and **only for repeater nodes** (same scope as the byte-size filter — companion, room, sensor, and observer nodes are unaffected). Based on `node.multibyte_sup`:
+
+| `multibyte_sup` | Marker style |
+|---|---|
+| `2` confirmed | Solid bright green fill (`#22c55e`), green border (`#16a34a`) |
+| `1` suspected | Light green fill (`#86efac`), dashed green border (`#22c55e`) |
+| `0` unknown | Existing role-based fill color unchanged, opacity reduced to `0.45` |
+
+When the toggle is **OFF**, all markers render exactly as today — no style changes.
+
+### Tooltip / popup
+
+When the overlay is active and a node is clicked, the popup shows the evidence label:
+- `multibyte_sup = 2` → "Multibyte: confirmed (advert)"
+- `multibyte_sup = 1` → "Multibyte: suspected (path)"
+- `multibyte_sup = 0` → "Multibyte: not detected"
+
+---
+
+## CPU / Performance Constraints
+
+- No startup scan. Status is read from the DB column, which persists across restarts.
+- Write-back runs on the existing analytics cache cycle (~15 s), not on packet arrival.
+- The no-downgrade guard (`multibyte_sup < ?`) ensures write-back becomes a no-op for nodes that have settled — cost decreases over time.
+- No bulk reprocessing at any point.
+
+---
+
+## Out of Scope
+
+- Ingestor changes — multibyte detection is entirely server-side.
+- New API endpoints — all data flows through the existing `/api/nodes` response.
+- Retroactive backfill on install — the overlay populates naturally as the analytics cycle runs. No migration backfill query needed.

--- a/public/analytics.js
+++ b/public/analytics.js
@@ -89,6 +89,7 @@
             <button class="tab-btn" data-tab="rf-health">RF Health</button>
             <button class="tab-btn" data-tab="clock-health">Clock Health</button>
             <button class="tab-btn" data-tab="prefix-tool">Prefix Tool</button>
+            <button class="tab-btn" data-tab="scopes">Scopes</button>
           </div>
         </div>
         <div id="analyticsContent" class="analytics-content" aria-live="polite">
@@ -184,6 +185,7 @@
       case 'rf-health': await renderRFHealthTab(el); break;
       case 'clock-health': await renderClockHealthTab(el); break;
       case 'prefix-tool': await renderPrefixTool(el); break;
+      case 'scopes': await renderScopesTab(el); break;
     }
     // Auto-apply column resizing to all analytics tables
     requestAnimationFrame(() => {
@@ -3565,6 +3567,132 @@ function destroy() { _analyticsData = {}; _channelData = null; if (_ngState && _
     } catch (err) {
       el.innerHTML = '<div class="text-center" style="color:var(--status-red);padding:40px">Failed to load clock health data: ' + esc(String(err)) + '</div>';
     }
+  }
+
+  // ===================== SCOPES =====================
+  async function renderScopesTab(el) {
+    var winKey = 'scopes_window';
+    var selectedWindow = (typeof sessionStorage !== 'undefined' && sessionStorage.getItem(winKey)) || '24h';
+
+    async function load(w) {
+      el.innerHTML = '<div class="text-center text-muted" style="padding:40px">Loading scope stats…</div>';
+      try {
+        var data = await (await fetch('/api/scope-stats?window=' + encodeURIComponent(w))).json();
+        if (data.error) {
+          el.innerHTML = '<div class="text-center text-muted" style="padding:40px">' + esc(data.error) + '</div>';
+          return;
+        }
+        render(data, w);
+      } catch (err) {
+        el.innerHTML = '<div class="text-center" style="color:var(--status-red);padding:40px">Failed to load scope stats: ' + esc(String(err)) + '</div>';
+      }
+    }
+
+    function pct(n, total) {
+      if (!total) return '—';
+      return (n / total * 100).toFixed(1) + '%';
+    }
+
+    function render(d, w) {
+      var s = d.summary;
+      var total = s.transportTotal || 0;
+
+      // Window selector
+      var winHtml = ['1h', '24h', '7d'].map(function(v) {
+        return '<button class="tab-btn' + (w === v ? ' active' : '') + '" data-win="' + v + '">' + v + '</button>';
+      }).join('');
+
+      // Summary cards
+      var cardsHtml = [
+        { label: 'Transport Total', value: total.toLocaleString(), note: '' },
+        { label: 'Scoped', value: s.scoped.toLocaleString(), note: pct(s.scoped, total) },
+        { label: 'Unscoped', value: s.unscoped.toLocaleString(), note: pct(s.unscoped, total) },
+        { label: 'Unknown Scope', value: s.unknownScope.toLocaleString(), note: pct(s.unknownScope, s.scoped) + ' of scoped' },
+      ].map(function(c) {
+        return '<div class="stat-card"><div class="stat-value">' + c.value + '</div>' +
+          '<div class="stat-label">' + c.label + '</div>' +
+          (c.note ? '<div class="stat-note text-muted" style="font-size:11px">' + c.note + '</div>' : '') +
+          '</div>';
+      }).join('');
+
+      // Per-region table
+      var tableBody = '';
+      if (d.byRegion && d.byRegion.length) {
+        tableBody = d.byRegion.map(function(r) {
+          return '<tr><td><code>' + esc(r.name) + '</code></td>' +
+            '<td>' + r.count.toLocaleString() + '</td>' +
+            '<td>' + pct(r.count, s.scoped) + '</td></tr>';
+        }).join('');
+        if (s.unknownScope > 0) {
+          tableBody += '<tr><td><em class="text-muted">Unknown scope</em></td>' +
+            '<td>' + s.unknownScope.toLocaleString() + '</td>' +
+            '<td>' + pct(s.unknownScope, s.scoped) + '</td></tr>';
+        }
+      } else if (s.scoped === 0) {
+        tableBody = '<tr><td colspan="3" class="text-muted" style="text-align:center">No scoped messages in this window</td></tr>';
+      } else {
+        tableBody = '<tr><td colspan="3" class="text-muted" style="text-align:center">No regions configured — add <code>hashRegions</code> to your config</td></tr>';
+      }
+
+      // Time-series chart (two-line SVG)
+      var chartHtml = '';
+      if (d.timeSeries && d.timeSeries.length > 1) {
+        var scopedVals = d.timeSeries.map(function(p) { return p.scoped; });
+        var unscopedVals = d.timeSeries.map(function(p) { return p.unscoped; });
+        var maxVal = Math.max(1, Math.max.apply(null, scopedVals.concat(unscopedVals)));
+        var W = 800, H = 180, padL = 44, padB = 24, padT = 10, padR = 10;
+        var plotW = W - padL - padR, plotH = H - padB - padT;
+        var n = d.timeSeries.length;
+
+        function pts(vals) {
+          return vals.map(function(v, i) {
+            var x = padL + i * plotW / Math.max(n - 1, 1);
+            var y = padT + plotH - (v / maxVal) * plotH;
+            return x.toFixed(1) + ',' + y.toFixed(1);
+          }).join(' ');
+        }
+
+        var grid = '';
+        for (var gi = 0; gi <= 4; gi++) {
+          var gy = padT + plotH * gi / 4;
+          var gv = Math.round(maxVal * (4 - gi) / 4);
+          grid += '<line x1="' + padL + '" y1="' + gy.toFixed(1) + '" x2="' + (W - padR) + '" y2="' + gy.toFixed(1) + '" stroke="var(--border)" stroke-dasharray="2"/>';
+          grid += '<text x="' + (padL - 4) + '" y="' + (gy + 4).toFixed(1) + '" text-anchor="end" font-size="9" fill="var(--text-muted)">' + gv + '</text>';
+        }
+
+        var legendX = padL + plotW - 120;
+        chartHtml = '<div style="margin-top:16px">' +
+          '<svg viewBox="0 0 ' + W + ' ' + H + '" style="width:100%;max-height:' + H + 'px" role="img" aria-label="Scope time series">' +
+          grid +
+          '<polyline points="' + pts(scopedVals) + '" fill="none" stroke="var(--accent)" stroke-width="2"/>' +
+          '<polyline points="' + pts(unscopedVals) + '" fill="none" stroke="var(--text-muted)" stroke-width="1.5" stroke-dasharray="4"/>' +
+          '<rect x="' + legendX + '" y="' + padT + '" width="10" height="10" fill="var(--accent)"/>' +
+          '<text x="' + (legendX + 14) + '" y="' + (padT + 9) + '" font-size="10" fill="var(--text)">Scoped</text>' +
+          '<rect x="' + legendX + '" y="' + (padT + 16) + '" width="10" height="10" fill="var(--text-muted)"/>' +
+          '<text x="' + (legendX + 14) + '" y="' + (padT + 25) + '" font-size="10" fill="var(--text)">Unscoped</text>' +
+          '</svg></div>';
+      }
+
+      el.innerHTML =
+        '<h3 style="margin:0 0 12px">Scope Statistics</h3>' +
+        '<div style="margin-bottom:12px">' + winHtml + '</div>' +
+        '<div class="stats-grid" style="margin-bottom:16px">' + cardsHtml + '</div>' +
+        '<table class="data-table analytics-table" style="margin-bottom:8px">' +
+        '<thead><tr><th>Region</th><th>Messages</th><th>% of Scoped</th></tr></thead>' +
+        '<tbody>' + tableBody + '</tbody></table>' +
+        chartHtml;
+
+      // Bind window selector
+      el.querySelectorAll('[data-win]').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          selectedWindow = btn.dataset.win;
+          if (typeof sessionStorage !== 'undefined') sessionStorage.setItem(winKey, selectedWindow);
+          load(selectedWindow);
+        });
+      });
+    }
+
+    load(selectedWindow);
   }
 
   registerPage('analytics', { init, destroy });

--- a/public/map.js
+++ b/public/map.js
@@ -9,7 +9,7 @@
   let nodes = [];
   let targetNodeKey = null;
   let observers = [];
-  let filters = { repeater: true, companion: true, room: true, sensor: true, observer: true, lastHeard: '30d', neighbors: false, clusters: false, hashLabels: localStorage.getItem('meshcore-map-hash-labels') !== 'false', statusFilter: localStorage.getItem('meshcore-map-status-filter') || 'all', byteSize: localStorage.getItem('meshcore-map-byte-filter') || 'all' };
+  let filters = { repeater: true, companion: true, room: true, sensor: true, observer: true, lastHeard: '30d', neighbors: false, clusters: false, hashLabels: localStorage.getItem('meshcore-map-hash-labels') !== 'false', statusFilter: localStorage.getItem('meshcore-map-status-filter') || 'all', byteSize: localStorage.getItem('meshcore-map-byte-filter') || 'all', multibyteOverlay: localStorage.getItem('meshcore-map-multibyte') === 'true' };
   let selectedReferenceNode = null;  // pubkey of the reference node for neighbor filtering
   let neighborPubkeys = null;        // Set of pubkeys that are direct neighbors of selected node
   let wsHandler = null;
@@ -25,20 +25,33 @@
 
   // Roles loaded from shared roles.js (ROLE_STYLE, ROLE_LABELS, ROLE_COLORS globals)
 
-  function makeMarkerIcon(role, isStale, isAlsoObserver) {
+  function makeMarkerIcon(role, isStale, isAlsoObserver, mbSup) {
     const s = ROLE_STYLE[role] || ROLE_STYLE.companion;
     const size = s.radius * 2 + 4;
     const c = size / 2;
+    let fill = s.color;
+    let stroke = '#fff';
+    let strokeExtra = '';
+    let svgOpacity = 1;
+    if (mbSup !== null && mbSup !== undefined) {
+      if (mbSup >= 2) {
+        fill = '#22c55e'; stroke = '#16a34a';
+      } else if (mbSup >= 1) {
+        fill = '#86efac'; stroke = '#22c55e'; strokeExtra = ' stroke-dasharray="3,2"';
+      } else {
+        svgOpacity = 0.45;
+      }
+    }
     let path;
     switch (s.shape) {
       case 'diamond':
-        path = `<polygon points="${c},2 ${size-2},${c} ${c},${size-2} 2,${c}" fill="${s.color}" stroke="#fff" stroke-width="2"/>`;
+        path = `<polygon points="${c},2 ${size-2},${c} ${c},${size-2} 2,${c}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
         break;
       case 'square':
-        path = `<rect x="3" y="3" width="${size-6}" height="${size-6}" fill="${s.color}" stroke="#fff" stroke-width="2"/>`;
+        path = `<rect x="3" y="3" width="${size-6}" height="${size-6}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
         break;
       case 'triangle':
-        path = `<polygon points="${c},2 ${size-2},${size-2} 2,${size-2}" fill="${s.color}" stroke="#fff" stroke-width="2"/>`;
+        path = `<polygon points="${c},2 ${size-2},${size-2} 2,${size-2}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
         break;
       case 'star': {
         // 5-pointed star
@@ -50,11 +63,11 @@
           pts += `${cx + outer * Math.cos(aOuter)},${cy + outer * Math.sin(aOuter)} `;
           pts += `${cx + inner * Math.cos(aInner)},${cy + inner * Math.sin(aInner)} `;
         }
-        path = `<polygon points="${pts.trim()}" fill="${s.color}" stroke="#fff" stroke-width="1.5"/>`;
+        path = `<polygon points="${pts.trim()}" fill="${fill}" stroke="${stroke}" stroke-width="1.5"${strokeExtra}/>`;
         break;
       }
       default: // circle
-        path = `<circle cx="${c}" cy="${c}" r="${c-2}" fill="${s.color}" stroke="#fff" stroke-width="2"/>`;
+        path = `<circle cx="${c}" cy="${c}" r="${c-2}" fill="${fill}" stroke="${stroke}" stroke-width="2"${strokeExtra}/>`;
     }
     // If this node is also an observer, add a small star overlay
     let obsOverlay = '';
@@ -71,7 +84,8 @@
       }
       obsOverlay = `<g transform="translate(${sx},${sy})"><polygon points="${starPts.trim()}" fill="${ROLE_COLORS.observer || '#f1c40f'}" stroke="#fff" stroke-width="0.8"/></g>`;
     }
-    const svg = `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">${path}${obsOverlay}</svg>`;
+    const svgOpacityAttr = svgOpacity < 1 ? ` opacity="${svgOpacity}"` : '';
+    const svg = `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg"${svgOpacityAttr}>${path}${obsOverlay}</svg>`;
     return L.divIcon({
       html: svg,
       className: 'meshcore-marker' + (isStale ? ' marker-stale' : ''),
@@ -81,15 +95,27 @@
     });
   }
 
-  function makeRepeaterLabelIcon(node, isStale, isAlsoObserver) {
+  function makeRepeaterLabelIcon(node, isStale, isAlsoObserver, mbSup) {
     var s = ROLE_STYLE['repeater'] || ROLE_STYLE.companion;
     var hs = node.hash_size || 1;
     // Show the short mesh hash ID (first N bytes of pubkey, uppercased)
     var shortHash = node.public_key ? node.public_key.slice(0, hs * 2).toUpperCase() : '??';
     var bgColor = s.color;
+    var textColor = '#fff';
+    var border = '2px solid #fff';
+    var extraStyle = '';
+    if (mbSup !== null && mbSup !== undefined) {
+      if (mbSup >= 2) {
+        bgColor = '#22c55e'; border = '2px solid #16a34a';
+      } else if (mbSup >= 1) {
+        bgColor = '#86efac'; textColor = '#14532d'; border = '2px dashed #22c55e';
+      } else {
+        extraStyle = 'opacity:0.45;';
+      }
+    }
     // If this repeater is also an observer, show a star indicator inside the label
     var obsIndicator = isAlsoObserver ? ' <span style="color:' + (ROLE_COLORS.observer || '#f1c40f') + ';font-size:13px;line-height:1;" title="Also an observer">★</span>' : '';
-    var html = '<div style="background:' + bgColor + ';color:#fff;font-weight:bold;font-size:11px;padding:2px 5px;border-radius:3px;border:2px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,0.4);text-align:center;line-height:1.2;white-space:nowrap;">' +
+    var html = '<div style="background:' + bgColor + ';color:' + textColor + ';font-weight:bold;font-size:11px;padding:2px 5px;border-radius:3px;border:' + border + ';box-shadow:0 1px 3px rgba(0,0,0,0.4);text-align:center;line-height:1.2;white-space:nowrap;' + extraStyle + '">' +
       shortHash + obsIndicator + '</div>';
     return L.divIcon({
       html: html,
@@ -119,6 +145,7 @@
               <button class="btn ${filters.byteSize==='2'?'active':''}" data-byte="2">2-byte</button>
               <button class="btn ${filters.byteSize==='3'?'active':''}" data-byte="3">3-byte</button>
             </div>
+            <label for="mcMultibyte" style="display:block;margin-top:6px;font-size:12px;cursor:pointer"><input type="checkbox" id="mcMultibyte" ${filters.multibyteOverlay?'checked':''}> Show multibyte capability</label>
           </fieldset>
           <fieldset class="mc-section">
             <legend class="mc-label">Display</legend>
@@ -302,6 +329,11 @@
         document.querySelectorAll('#mcByteFilter .btn').forEach(b => b.classList.toggle('active', b.dataset.byte === filters.byteSize));
         renderMarkers();
       });
+    });
+    document.getElementById('mcMultibyte').addEventListener('change', function(e) {
+      filters.multibyteOverlay = e.target.checked;
+      localStorage.setItem('meshcore-map-multibyte', e.target.checked);
+      renderMarkers();
     });
 
     // Geo filter overlay
@@ -811,7 +843,10 @@
       const pk = (node.public_key || '').toLowerCase();
       const isAlsoObserver = _observerByPubkey.has(pk);
       const useLabel = node.role === 'repeater' && filters.hashLabels;
-      const icon = useLabel ? makeRepeaterLabelIcon(node, isStale, isAlsoObserver) : makeMarkerIcon(node.role || 'companion', isStale, isAlsoObserver);
+      const mbSup = (filters.multibyteOverlay && node.role === 'repeater')
+        ? (typeof node.multibyte_sup === 'number' ? node.multibyte_sup : 0)
+        : null;
+      const icon = useLabel ? makeRepeaterLabelIcon(node, isStale, isAlsoObserver, mbSup) : makeMarkerIcon(node.role || 'companion', isStale, isAlsoObserver, mbSup);
       const latLng = L.latLng(node.lat, node.lon);
       allMarkers.push({ latLng, node, icon, isLabel: useLabel, popupFn: function() { return buildPopup(node); }, alt: (node.name || 'Unknown') + ' (' + (node.role || 'node') + (isAlsoObserver ? ' + observer' : '') + ')' });
     }
@@ -947,6 +982,13 @@
     const hashPrefix = node.public_key ? node.public_key.slice(0, hs * 2).toUpperCase() : '—';
     const hashPrefixRow = `<dt style="color:var(--text-muted);float:left;clear:left;width:80px;padding:2px 0;">Hash Prefix</dt>
           <dd style="font-family:var(--mono);font-size:11px;font-weight:700;margin-left:88px;padding:2px 0;">${safeEsc(hashPrefix)} <span style="font-weight:400;color:var(--text-muted);">(${hs}B)</span></dd>`;
+    const mbSup = typeof node.multibyte_sup === 'number' ? node.multibyte_sup : 0;
+    const mbLabel = mbSup >= 2 ? 'confirmed (advert)' : mbSup >= 1 ? 'suspected (path)' : 'not detected';
+    const mbColor = mbSup >= 2 ? '#22c55e' : mbSup >= 1 ? '#86efac' : '#9ca3af';
+    const mbRow = (filters.multibyteOverlay && node.role === 'repeater')
+      ? `<dt style="color:var(--text-muted);float:left;clear:left;width:80px;padding:2px 0;">Multibyte</dt>
+          <dd style="color:${mbColor};margin-left:88px;padding:2px 0;">${safeEsc(mbLabel)}</dd>`
+      : '';
 
     return `
       <div class="map-popup" style="font-family:var(--font);min-width:180px;">
@@ -954,6 +996,7 @@
         ${roleBadge}${obsBadge}
         <dl style="margin-top:8px;font-size:12px;">
           ${hashPrefixRow}
+          ${mbRow}
           <dt style="color:var(--text-muted);float:left;clear:left;width:80px;padding:2px 0;">Key</dt>
           <dd style="font-family:var(--mono);font-size:11px;margin-left:88px;padding:2px 0;">${safeEsc(key)}</dd>
           <dt style="color:var(--text-muted);float:left;clear:left;width:80px;padding:2px 0;">Location</dt>

--- a/public/map.js
+++ b/public/map.js
@@ -250,6 +250,9 @@
     markerLayer = L.layerGroup().addTo(map);
     routeLayer = L.layerGroup().addTo(map);
 
+    map.on('popupopen',  () => { _popupOpen = true; });
+    map.on('popupclose', () => { _popupOpen = false; });
+
     // Fix map size on SPA load
     setTimeout(() => map.invalidateSize(), 100);
 
@@ -558,7 +561,7 @@
       buildRoleChecks(data.counts || {});
       buildJumpButtons();
 
-      renderMarkers();
+      if (!_popupOpen) renderMarkers();
 
       // Restore heatmap if previously enabled
       if (localStorage.getItem('meshcore-map-heatmap') === 'true') {
@@ -686,6 +689,7 @@
   }
 
   var _renderingMarkers = false;
+  var _popupOpen = false;        // true while any marker popup is visible
   var _lastDeconflictZoom = null;
   var _currentMarkerData = []; // stored marker data for zoom-only repositioning
   var _observerByPubkey = new Map(); // observer id (pubkey) → observer object, rebuilt on each render

--- a/public/packets.js
+++ b/public/packets.js
@@ -2012,6 +2012,7 @@
         <dt>Location</dt><dd>${locationHtml}</dd>
         <dt>SNR / RSSI</dt><dd>${snr != null ? snr + ' dB' : '—'} / ${rssi != null ? rssi + ' dBm' : '—'}</dd>
         <dt>Route Type</dt><dd>${routeTypeName(pkt.route_type)}</dd>
+        ${pkt.scope_name != null ? `<dt>Scope</dt><dd>${pkt.scope_name !== '' ? escapeHtml(pkt.scope_name) : '<span style="color:var(--text-muted)">unknown scope</span>'}</dd>` : ''}
         <dt>Payload Type</dt><dd><span class="badge badge-${payloadTypeColor(pkt.payload_type)}">${typeName}</span></dd>
         ${hashSize ? `<dt>Hash Size</dt><dd>${hashSize} byte${hashSize !== 1 ? 's' : ''}</dd>` : ''}
         <dt>Timestamp</dt><dd>${renderTimestampCell(effectivePkt.timestamp)}</dd>


### PR DESCRIPTION
## Summary

### #899 — Scoped/unscoped transport-route statistics

- Adds `hashRegions` config to the ingestor — region names whose HMAC-SHA256 keys are derived at startup, mirroring the existing `hashChannels` pattern
- At ingest, transport-route packets with Code1 ≠ `0000` are HMAC-matched against configured region keys; result stored in new `scope_name` column
- DB migration `scope_name_v1` adds the column; scope matching runs only on new packets (no backfill goroutine)
- New `GET /api/scope-stats?window=` endpoint (1h/24h/7d, 30s TTL) returning transport totals, scoped/unscoped counts, per-region breakdown, and time-series
- New **Scopes** tab in the Analytics page with summary cards, per-region table, and two-line SVG chart

### #903 — Multibyte capability map overlay

- Adds `multibyte_sup` / `multibyte_evidence` columns to `nodes` + `inactive_nodes` via ingestor migration (`multibyte_sup_v1`)
- Server detects the columns at startup and enriches all `/api/nodes` responses: `multibyte_sup` = 0/1/2, `multibyte_evidence` = `"advert"` / `"path"` / `null`
- `persistMultiByteCapability()` upserts status from the existing analytics cycle (~15s) — no startup scan, no per-packet cost, no downgrade possible
- Map controls get a **"Show multibyte capability"** toggle (under Byte Size, persisted in localStorage); repeater markers colored: solid green = confirmed, light green dashed = suspected, dimmed = unknown
- Popup shows evidence label when overlay is active

### fix — OOM crash on cold start with large DB

`Load()` previously loaded all transmissions from the DB regardless of `retentionHours`, so `buildSubpathIndex()` processed the full DB history on every startup. On a DB with 277K paths this produces 13.5M subpath index entries and OOM-kills the process before it ever starts listening — causing a supervisord crash loop.

Fix: apply the same `retentionHours` cutoff to `Load()`'s SQL that `EvictStale()` already uses at runtime. Startup now builds indexes only over the configured retention window, making startup time proportional to recent activity rather than total DB history.

## Test plan

- [ ] Run `cd cmd/ingestor && go test ./...` — covers schema migrations for both `scope_name_v1` and `multibyte_sup_v1`
- [ ] Run `cd cmd/server && go test ./...` — covers scope stats, node enrichment, `persistMultiByteCapability`, and retention-filtered `Load()`
- [ ] Add `"hashRegions": ["#yourregion"]` to ingestor config, restart, verify `scope_name` column gets populated
- [ ] Open Analytics → Scopes tab, verify summary cards and window selector work
- [ ] Open Map, toggle "Show multibyte capability" — repeater markers change color, toggle state survives reload
- [ ] Click a repeater with the overlay active — popup shows confirmed/suspected/not detected
- [ ] Verify non-repeater nodes are unaffected by the multibyte toggle
- [ ] Restart server with a large DB — verify it reaches "listening" within the retention window load time

Closes #899
Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)