### PR TITLE
feat(live): node filter — show only traffic through a specific node (closes #771 M3)

### DIFF
--- a/public/live.js
+++ b/public/live.js
@@ -22,6 +22,9 @@
   let showOnlyFavorites = localStorage.getItem('live-favorites-only') === 'true';
   let matrixMode = localStorage.getItem('live-matrix-mode') === 'true';
   let matrixRain = localStorage.getItem('live-matrix-rain') === 'true';
+  let nodeFilterKeys = (localStorage.getItem('live-node-filter') || '').split(',').map(s => s.trim()).filter(Boolean);
+  let nodeFilterTotal = 0;
+  let nodeFilterShown = 0;
   let rainCanvas = null, rainCtx = null, rainDrops = [], rainRAF = null;
   const propagationBuffer = new Map(); // hash -> {timer, packets[]}
   let _onResize = null;
@@ -833,6 +836,12 @@
             <span id="audioDesc" class="sr-only">Sonify packets — turn raw bytes into generative music</span>
             <label><input type="checkbox" id="liveFavoritesToggle" aria-describedby="favDesc"> ⭐ Favorites</label>
             <span id="favDesc" class="sr-only">Show only favorited and claimed nodes</span>
+            <div class="live-node-filter-wrap">
+              <input type="text" id="liveNodeFilterInput" list="liveNodeFilterList" placeholder="Filter by node…" autocomplete="off" class="live-node-filter-input">
+              <datalist id="liveNodeFilterList"></datalist>
+              <button id="liveNodeFilterClear" class="vcr-btn" title="Clear node filter" style="display:none">×</button>
+            </div>
+            <div id="liveNodeFilterCount" class="live-filter-count hidden"></div>
             <label id="liveGeoFilterLabel" style="display:none"><input type="checkbox" id="liveGeoFilterToggle"> Mesh live area</label>
           </div>
           <div class="audio-controls hidden" id="audioControls">
@@ -990,6 +999,35 @@
       localStorage.setItem('live-favorites-only', showOnlyFavorites);
       applyFavoritesFilter();
     });
+
+    // Node filter input
+    const nodeFilterInput = document.getElementById('liveNodeFilterInput');
+    const nodeFilterClear = document.getElementById('liveNodeFilterClear');
+    if (nodeFilterInput) {
+      // Restore from URL param or localStorage
+      const urlNode = getHashParams && getHashParams().get('node');
+      if (urlNode) setNodeFilter(urlNode.split(',').map(s => s.trim()).filter(Boolean));
+      else if (nodeFilterKeys.length) updateNodeFilterUI();
+
+      nodeFilterInput.addEventListener('change', (e) => {
+        const val = e.target.value.trim();
+        setNodeFilter(val ? val.split(',').map(s => s.trim()).filter(Boolean) : []);
+        const params = getHashParams ? getHashParams() : new URLSearchParams();
+        if (nodeFilterKeys.length) params.set('node', nodeFilterKeys.join(','));
+        else params.delete('node');
+        const base = location.hash.split('?')[0];
+        const qs = params.toString();
+        location.hash = base + (qs ? '?' + qs : '');
+      });
+    }
+    if (nodeFilterClear) {
+      nodeFilterClear.addEventListener('click', () => {
+        if (nodeFilterInput) nodeFilterInput.value = '';
+        setNodeFilter([]);
+        const base = location.hash.split('?')[0];
+        location.hash = base;
+      });
+    }
 
     // Geo filter overlay
     (async function () {
@@ -1656,6 +1694,47 @@
     return getFavoritePubkeys().some(f => f === pubkey);
   }
 
+  function packetInvolvesFilterNode(pkt, filterKeys) {
+    if (!filterKeys.length) return true;
+    const hops = (pkt.decoded?.path?.hops) || [];
+    for (const hop of hops) {
+      const h = (hop.id || hop.public_key || hop).toString().toLowerCase();
+      if (filterKeys.some(f => f.toLowerCase().startsWith(h) || h.startsWith(f.toLowerCase()))) return true;
+    }
+    return false;
+  }
+
+  function setNodeFilter(keys) {
+    nodeFilterKeys = keys;
+    nodeFilterTotal = 0;
+    nodeFilterShown = 0;
+    localStorage.setItem('live-node-filter', keys.join(','));
+    updateNodeFilterUI();
+  }
+
+  function updateNodeFilterUI() {
+    const countEl = document.getElementById('liveNodeFilterCount');
+    const clearBtn = document.getElementById('liveNodeFilterClear');
+    const input = document.getElementById('liveNodeFilterInput');
+    if (nodeFilterKeys.length > 0) {
+      if (clearBtn) clearBtn.style.display = '';
+      if (countEl) { countEl.textContent = `Showing ${nodeFilterShown} of ${nodeFilterTotal}`; countEl.classList.remove('hidden'); }
+      if (input && input.value !== nodeFilterKeys.join(', ')) input.value = nodeFilterKeys.join(', ');
+    } else {
+      if (clearBtn) clearBtn.style.display = 'none';
+      if (countEl) countEl.classList.add('hidden');
+    }
+    updateNodeFilterDatalist();
+  }
+
+  function updateNodeFilterDatalist() {
+    const dl = document.getElementById('liveNodeFilterList');
+    if (!dl) return;
+    dl.innerHTML = Object.values(nodeData).map(n =>
+      `<option value="${n.public_key}">${n.name || n.public_key.slice(0, 8)}</option>`
+    ).join('');
+  }
+
   function rebuildFeedList() {
     const feed = document.getElementById('liveFeed');
     if (!feed) return;
@@ -1862,6 +1941,9 @@
   window._liveGetFavoritePubkeys = getFavoritePubkeys;
   window._livePacketInvolvesFavorite = packetInvolvesFavorite;
   window._liveIsNodeFavorited = isNodeFavorited;
+  window._livePacketInvolvesFilterNode = packetInvolvesFilterNode;
+  window._liveGetNodeFilterKeys = function() { return nodeFilterKeys; };
+  window._liveSetNodeFilter = setNodeFilter;
   window._liveFormatLiveTimestampHtml = formatLiveTimestampHtml;
   window._liveResolveHopPositions = resolveHopPositions;
   window._liveVcrSpeedCycle = vcrSpeedCycle;
@@ -1951,6 +2033,14 @@
 
     // --- Favorites filter ---
     if (showOnlyFavorites && !packets.some(function(p) { return packetInvolvesFavorite(p); })) return;
+
+    // --- Node filter ---
+    if (nodeFilterKeys.length) {
+      nodeFilterTotal++;
+      if (!packets.some(function(p) { return packetInvolvesFilterNode(p, nodeFilterKeys); })) return;
+      nodeFilterShown++;
+      updateNodeFilterUI();
+    }
 
     // --- Ensure ADVERT nodes appear on map ---
     for (var pi = 0; pi < packets.length; pi++) {

--- a/test-live.js
+++ b/test-live.js
@@ -928,6 +928,56 @@ console.log('\n=== live.js: source-level safety checks ===');
   });
 }
 
+// ===== Node filter (M3 — #771) =====
+console.log('\n=== live.js: node filter ===');
+{
+  const ctx = makeLiveSandbox();
+  const pktInvolvesFilter = ctx.window._livePacketInvolvesFilterNode;
+  assert.ok(pktInvolvesFilter, '_livePacketInvolvesFilterNode must be exposed');
+
+  const makePkt = (hops) => ({ decoded: { path: { hops }, payload: {} } });
+
+  test('packetInvolvesFilterNode returns true when filter is empty', () => {
+    assert.strictEqual(pktInvolvesFilter(makePkt(['abcd1234']), []), true);
+  });
+
+  test('packetInvolvesFilterNode matches hop by prefix', () => {
+    assert.strictEqual(pktInvolvesFilter(makePkt(['abcd1234', 'ef012345']), ['abcd1234567890ab']), true);
+  });
+
+  test('packetInvolvesFilterNode matches full key against short hop', () => {
+    assert.strictEqual(pktInvolvesFilter(makePkt(['abcd']), ['abcd1234567890ab']), true);
+  });
+
+  test('packetInvolvesFilterNode returns false when no hop matches', () => {
+    assert.strictEqual(pktInvolvesFilter(makePkt(['ffff1234', '00001111']), ['abcd1234567890ab']), false);
+  });
+
+  test('packetInvolvesFilterNode matches any of multiple filter keys (OR logic)', () => {
+    assert.strictEqual(pktInvolvesFilter(makePkt(['ffff0000']), ['abcd1234', 'ffff0000']), true);
+  });
+
+  test('packetInvolvesFilterNode returns false for packet with no hops', () => {
+    assert.strictEqual(pktInvolvesFilter(makePkt([]), ['abcd1234']), false);
+  });
+
+  const getNodeFilterKeys = ctx.window._liveGetNodeFilterKeys;
+  assert.ok(getNodeFilterKeys, '_liveGetNodeFilterKeys must be exposed');
+
+  test('node filter defaults to empty array when localStorage is unset', () => {
+    assert.strictEqual(getNodeFilterKeys().length, 0);
+  });
+
+  test('node filter saves to localStorage when set', () => {
+    const setFilter = ctx.window._liveSetNodeFilter;
+    assert.ok(setFilter, '_liveSetNodeFilter must be exposed');
+    setFilter(['abcd1234', 'ef012345']);
+    assert.strictEqual(ctx.localStorage.getItem('live-node-filter'), 'abcd1234,ef012345');
+    setFilter([]);
+    assert.strictEqual(ctx.localStorage.getItem('live-node-filter'), '');
+  });
+}
+
 // ===== SUMMARY =====
 Promise.allSettled(pendingTests).then(() => {
   console.log(`\n${'═'.repeat(40)}`);


### PR DESCRIPTION
Adds a node filter input to the live controls bar. When active, only packets whose hop chain passes through the selected node(s) are animated. A counter shows "Showing X of Y" so operators know traffic is filtered, not absent.

## Changes
- `packetInvolvesFilterNode(pkt, filterKeys)`: pure filter function using same prefix-matching logic as the favorites filter
- `setNodeFilter(keys)`: sets filter state, resets counters, persists to localStorage
- `updateNodeFilterUI()`: updates counter + clear button visibility + datalist autocomplete
- Filter input in controls bar (after Favorites toggle): text input + datalist autocomplete + × clear button + counter div
- Filter wired into `renderPacketTree`: increments total/shown counters, returns early when packet doesn't match
- URL hash sync: `?node=ABCD1234` — read on init, written on filter change

## Tests
8 new unit tests covering filter logic, localStorage persistence, and edge cases; 78 pass, 0 regressions.

Closes #771 (M3 of 3)