### PR TITLE
fix(ingestor): unblock startup when one of multiple MQTT sources is unreachable

### DIFF
--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -114,6 +114,7 @@ func main() {
 
 	// Connect to each MQTT source
 	var clients []mqtt.Client
+	connectedCount := 0
 	for _, source := range sources {
 		tag := source.Name
 		if tag == "" {
@@ -167,11 +168,19 @@ func main() {
 
 		client := mqtt.NewClient(opts)
 		token := client.Connect()
-		token.Wait()
+		// With ConnectRetry=true, token.Wait() blocks forever for unreachable brokers.
+		// WaitTimeout lets startup proceed; the client keeps retrying in the background
+		// and OnConnect fires (subscribing) when it eventually connects (#910).
+		if !token.WaitTimeout(30 * time.Second) {
+			log.Printf("MQTT [%s] initial connection timed out — retrying in background", tag)
+			clients = append(clients, client)
+			continue
+		}
 		if token.Error() != nil {
 			log.Printf("MQTT [%s] connection failed (non-fatal): %v", tag, token.Error())
 			continue
 		}
+		connectedCount++
 		clients = append(clients, client)
 	}
 
@@ -179,7 +188,11 @@ func main() {
 		log.Fatal("no MQTT connections established — check broker is running (default: mqtt://localhost:1883). Set MQTT_BROKER env var or configure mqttSources in config.json")
 	}
 
-	log.Printf("Running — %d MQTT source(s) connected", len(clients))
+	if connectedCount < len(clients) {
+		log.Printf("Running — %d MQTT source(s) connected, %d retrying in background", connectedCount, len(clients)-connectedCount)
+	} else {
+		log.Printf("Running — %d MQTT source(s) connected", connectedCount)
+	}
 
 	// Wait for shutdown signal
 	sig := make(chan os.Signal, 1)

--- a/cmd/ingestor/main_test.go
+++ b/cmd/ingestor/main_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
 func TestToFloat64(t *testing.T) {
@@ -778,5 +780,30 @@ func TestIATAFilterDoesNotDropStatusMessages(t *testing.T) {
 	store.db.QueryRow("SELECT COUNT(*) FROM transmissions").Scan(&count)
 	if count != 0 {
 		t.Error("packet from out-of-region BFL should still be filtered by IATA")
+	}
+}
+
+// TestMQTTConnectRetryTimeoutDoesNotBlock verifies that WaitTimeout returns within
+// the deadline for an unreachable broker when ConnectRetry=true (#910). Previously,
+// token.Wait() would block forever in this configuration.
+func TestMQTTConnectRetryTimeoutDoesNotBlock(t *testing.T) {
+	opts := mqtt.NewClientOptions().
+		AddBroker("tcp://127.0.0.1:1"). // port 1 — nothing listening, fast refusal
+		SetConnectRetry(true).
+		SetAutoReconnect(true)
+
+	client := mqtt.NewClient(opts)
+	token := client.Connect()
+	defer client.Disconnect(100)
+
+	start := time.Now()
+	connected := token.WaitTimeout(3 * time.Second)
+	elapsed := time.Since(start)
+
+	if connected {
+		t.Skip("port 1 unexpectedly accepted a connection — skipping")
+	}
+	if elapsed > 4*time.Second {
+		t.Errorf("WaitTimeout blocked for %v — token.Wait() would block forever with ConnectRetry=true", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

- With `ConnectRetry=true`, paho's `token.Wait()` only returns on success — it blocks forever for unreachable brokers, stalling the entire startup loop before any other source connects
- Switches to `token.WaitTimeout(30s)`: on timeout the client is still tracked so `ConnectRetry` keeps retrying in background; `OnConnect` fires and subscribes when it eventually connects
- Adds `TestMQTTConnectRetryTimeoutDoesNotBlock` to confirm `WaitTimeout` returns within deadline for unreachable brokers (regression guard for this exact failure mode)

Fixes #910

## Test plan

- [x] Two MQTT sources configured, one unreachable: ingestor reaches `Running` status and ingests from the reachable source immediately on startup
- [x] Unreachable source logs `initial connection timed out — retrying in background` and reconnects automatically when the broker comes back
- [x] Single source, reachable: behaviour unchanged (`Running — 1 MQTT source(s) connected`)
- [x] Single source, unreachable: `Running — 0 MQTT source(s) connected, 1 retrying in background`; ingestion starts once broker is available
- [x] `go test ./...` passes (excluding pre-existing `TestOpenStoreInvalidPath` failure on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)