### PR TITLE
fix(customize): skip panel re-render while a text field has focus

### DIFF
--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -629,7 +629,11 @@
       }
       writeOverrides(delta);
       _runPipeline();
-      _refreshPanel();
+      // Skip re-render while the user is typing inside the panel — setting
+      // innerHTML would destroy the focused input and collapse the mobile keyboard.
+      if (!(_panelEl && _panelEl.contains(document.activeElement))) {
+        _refreshPanel();
+      }
     }, 300);
   }
 

--- a/test-e2e-playwright.js
+++ b/test-e2e-playwright.js
@@ -1358,6 +1358,38 @@ async function run() {
     await page.evaluate(() => localStorage.removeItem('cs-theme-overrides'));
   });
 
+  await test('Customizer v2: typing in text field does not collapse focus (re-render guard)', async () => {
+    await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('nav, .navbar, .nav, [class*="nav"]');
+    await page.waitForFunction(() => window._customizerV2 && window._customizerV2.initDone, { timeout: 5000 });
+    const toggleSel = '#customizeToggle, button[title*="ustom" i], [class*="customize"]';
+    const btn = await page.$(toggleSel);
+    if (!btn) { console.log('    ⏭️  Customizer toggle not found'); return; }
+    await btn.click();
+    await page.waitForSelector('.cust-overlay', { timeout: 5000 });
+    const result = await page.evaluate(() => {
+      const input = document.querySelector('.cust-overlay input[type="text"][data-cv2-field]');
+      if (!input) return { skipped: true };
+      input.focus();
+      input.value = 'test';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      const inputRef = input;
+      return new Promise(resolve => {
+        setTimeout(() => {
+          const panel = document.querySelector('.cust-overlay');
+          resolve({
+            inputConnected: inputRef.isConnected,
+            focusInPanel: panel ? panel.contains(document.activeElement) : false,
+          });
+        }, 500);
+      });
+    });
+    if (result.skipped) { console.log('    ⏭️  No text input with data-cv2-field found in panel'); return; }
+    assert(result.inputConnected, 'Input element should remain connected to DOM after debounce fires');
+    assert(result.focusInPanel, 'Focus should remain inside panel after debounce — re-render must not run while typing');
+    await page.evaluate(() => localStorage.removeItem('cs-theme-overrides'));
+  });
+
 
   await test('Show Neighbors populates neighborPubkeys from affinity API', async () => {
     const testPubkey = 'aabbccdd11223344556677889900aabbccddeeff00112233445566778899001122';


### PR DESCRIPTION
## Summary

- `_debouncedWrite()` was calling `_refreshPanel()` 300ms after every keystroke
- `_refreshPanel()` sets `container.innerHTML`, destroying the focused input element
- On mobile, losing the focused input collapses the virtual keyboard after each keypress

Guard the `_refreshPanel()` call so it is skipped when `document.activeElement` is inside the panel. The pipeline (`_runPipeline`) still runs immediately — CSS updates apply. Override dots update on the next natural re-render (tab switch, dark-mode toggle, panel reopen).

## Root cause

`customize-v2.js` → `_debouncedWrite()` → `_refreshPanel()` → `_renderPanel()` → `container.innerHTML = ...`

## Test plan

- [ ] New Playwright E2E test: open Customize, focus a text field, type, wait 500ms past debounce — asserts input element is still connected to DOM and focus remains inside panel
- [ ] Manual: open Customize on mobile (or DevTools mobile emulation), type in Site Name — keyboard must not collapse after each character

Fixes #896
