### PR TITLE
fix(ui): align filter-bar heights and compact MESH LIVE panel

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -719,13 +719,13 @@ input[type="week"] {
 .filter-bar .btn {
   padding: 6px 14px; border: 1px solid var(--border); border-radius: 6px;
   background: var(--input-bg); cursor: pointer; font-size: 13px; transition: all .15s;
-  font-family: var(--font); color: var(--text); height: 34px; box-sizing: border-box; line-height: 1;
+  font-family: var(--font); color: var(--text); height: 34px; min-height: 34px; box-sizing: border-box; line-height: 1;
 }
 .filter-group { display: flex; gap: 6px; align-items: center; }
 /* #1124 (MAJOR-3): each grouped cluster wraps as a single unit at narrow
  * widths instead of letting individual controls reflow across categories. */
 .filter-bar .filter-group { flex-wrap: nowrap; }
-.filter-group .btn { padding: 4px 10px; font-size: 12px; border-radius: 12px; border: 1px solid var(--border); background: var(--input-bg); color: var(--text); cursor: pointer; transition: background 0.15s, color 0.15s; }
+.filter-group .btn { padding: 4px 10px; font-size: 12px; border-radius: 12px; border: 1px solid var(--border); background: var(--input-bg); color: var(--text); cursor: pointer; transition: background 0.15s, color 0.15s; height: 34px; min-height: 34px; box-sizing: border-box; line-height: 1; }
 .filter-group .btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
 .filter-group .btn:hover:not(.active) { background: var(--surface-2); }
 .filter-group + .filter-group { border-left: 1px solid var(--border); padding-left: 12px; margin-left: 6px; }
@@ -740,6 +740,7 @@ input[type="week"] {
 .sort-help:hover .sort-help-tip { display: block; }
 .filter-bar .btn:hover { background: var(--row-hover); }
 .filter-bar .btn.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.filter-bar .col-toggle-btn { height: 34px; min-height: 34px; }
 
 .btn-icon {
   background: none; border: 1px solid var(--border); border-radius: 6px;


### PR DESCRIPTION
## Summary

- **Filter bar heights**: `.btn` and `.col-toggle-btn` carried `min-height:48px` from the WCAG touch-target rule, making buttons like `Group by Hash`, `★ My Nodes`, `Columns ▾`, and text inputs visibly taller than the `multi-select-trigger` / `region-dropdown-trigger` controls (which don't carry `.btn` and were already correct at 34px). Fix adds `min-height:34px` overrides to `.filter-bar .btn`, `.filter-group .btn`, `.filter-bar .col-toggle-btn`, and `.filter-bar input, .filter-bar select` so the entire filter bar renders at a uniform 34px on desktop.

- **MESH LIVE panel**: `.live-overlay` sets `flex-direction:column` on all overlay panels; `.live-header` did not override this. With `#liveAreaFilter` populated (when areas are configured), the panel stacked 4 rows — title, stats, toggles, area filter — consuming ~⅓ of viewport height. Switch `.live-header` to `flex-direction:row; flex-wrap:wrap`, give `.live-toggles` `flex:0 0 100%` to force it to its own line, and move `#liveAreaFilter` inside `.live-toggles` so the area dropdown is inline with the other controls. Panel shrinks from 4 rows to 2 rows.

## Test plan

- [x] Packets page filter bar: `Filters ▾`, text inputs, `All Observers`, `All Types`, `Group by Hash`, `★ My Nodes`, `Columns ▾`, `Hex Paths` all render at uniform ~34px height on desktop
- [x] Mobile (≤767px): filter bar touch targets unaffected (mobile media query still authoritative)
- [x] Live page: MESH LIVE panel occupies 2 rows (title+stats / toggles) instead of 4
- [x] Live page: `Area: All ▾` appears inline in the toggles row when areas are configured; panel hides the area control entirely when no areas are configured (existing behavior)
- [x] Audio controls still appear correctly when the Audio toggle is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)