### PR TITLE
fix(analytics): align region filter and time-window select in a single row

### DIFF
--- a/public/analytics.js
+++ b/public/analytics.js
@@ -96,10 +96,9 @@
         <div class="analytics-header">
           <h2>📊 Mesh Analytics</h2>
           <p class="text-muted">Deep dive into your mesh network data</p>
-          <div id="analyticsRegionFilter" class="region-filter-container"></div>
-          <div class="time-window-filter" style="margin:8px 0">
-            <label for="analyticsTimeWindow" style="font-size:0.9em;color:var(--text-muted);margin-right:6px">Time window:</label>
-            <select id="analyticsTimeWindow" data-testid="analytics-time-window" aria-label="Time window">
+          <div class="analytics-filters">
+            <div id="analyticsRegionFilter" class="region-filter-container"></div>
+            <select id="analyticsTimeWindow" class="analytics-time-window-select" data-testid="analytics-time-window" aria-label="Time window">
               <option value="">All data</option>
               <option value="1h">Last 1 hour</option>
               <option value="24h">Last 24 hours</option>

--- a/public/style.css
+++ b/public/style.css
@@ -2535,6 +2535,13 @@ tr[data-hops]:hover { background: rgba(59,130,246,0.1); }
   font-size: 12px; font-weight: 600; color: var(--text-muted); align-self: center;
   margin-right: 2px; user-select: none;
 }
+.analytics-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 8px 0; }
+.analytics-time-window-select {
+  height: 34px; min-height: 34px; padding: 0 10px; border-radius: 6px; box-sizing: border-box;
+  font-size: 13px; font-weight: 500; cursor: pointer; border: 1px solid var(--border);
+  background: var(--input-bg); color: var(--text); transition: border-color 0.15s;
+}
+.analytics-time-window-select:hover { border-color: var(--accent); }
 .region-dropdown-wrap { position: relative; display: inline-flex; align-items: center; }
 .region-dropdown-trigger {
   display: inline-flex; align-items: center; padding: 6px 10px; border-radius: 6px;


### PR DESCRIPTION
## Summary

- Wraps the region filter and time-window `<select>` in a `.analytics-filters` flex container so they sit side-by-side at the same height
- Adds `.analytics-time-window-select` CSS class to match the `region-dropdown-trigger` button appearance (34px height, same border/font/radius)
- Overrides the global `select { min-height: 48px }` touch target rule that was making the select taller than the region button
- Removes the separate "Time window:" label — the select speaks for itself

## Test plan

- [ ] Open Analytics page — region filter and time-window select appear in a single row
- [ ] Both controls are the same height (~34px)
- [ ] Time-window select hover shows accent border, matching region button hover
- [ ] Selecting a time window still triggers a data reload
- [ ] On mobile, the controls wrap to a second line (flex-wrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)