### PR TITLE
fix(live): pass pktMeta.hash to drawAnimatedLine — merge artifact from #923 broke line animation

### DIFF
--- a/public/live.js
+++ b/public/live.js
@@ -2888,7 +2888,7 @@
         const nextGhost = hopPositions[hopIndex + 1].ghost;
         const lineColor = (isGhost || nextGhost) ? '#94a3b8' : color;
         const lineOpacity = (isGhost || nextGhost) ? 0.3 : undefined;
-        drawAnimatedLine(hp.pos, nextPos, lineColor, () => { hopIndex++; nextHop(); }, lineOpacity, rawHex, hash);
+        drawAnimatedLine(hp.pos, nextPos, lineColor, () => { hopIndex++; nextHop(); }, lineOpacity, rawHex, pktMeta?.hash);
       } else {
         if (!isGhost) pulseNode(hp.key, hp.pos, typeName);
         hopIndex++; nextHop();


### PR DESCRIPTION
## Summary

- `animatePath` signature changed from `(..., hash)` to `(..., pktMeta)` when #923 was merged
- The `drawAnimatedLine` call inside `nextHop()` still referenced the bare `hash` variable, which is no longer in scope
- This causes a `ReferenceError` on every hop iteration, aborting the chain after the first pulse dot — **animated lines never draw**, only blinking dots appear

## Fix

Replace `hash` → `pktMeta?.hash` on the single affected `drawAnimatedLine` call (line 2891 in `public/live.js`).

## Test plan

- [ ] Open MESH LIVE page with live MQTT data flowing
- [ ] Confirm animated path lines draw between nodes (not just blinking dots)
- [ ] Confirm clickable path popups still work (pktMeta.hash still passed correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)