### PR TITLE
fix(live): add dark/light toggle to live-header-critical strip

### DIFF
--- a/public/live.css
+++ b/public/live.css
@@ -121,7 +121,8 @@
    operability rule). Visible glyph stays small (decorative); transparent
    padding expands the hit area without changing the visual chrome. */
 .live-header-toggle,
-.live-controls-toggle {
+.live-controls-toggle,
+.live-dark-toggle {
   display: none;
   align-items: center;
   justify-content: center;
@@ -141,13 +142,19 @@
   flex-shrink: 0;
 }
 .live-header-toggle:hover,
-.live-controls-toggle:hover {
+.live-controls-toggle:hover,
+.live-dark-toggle:hover {
   background: color-mix(in srgb, var(--text) 14%, transparent);
 }
 .live-header-toggle:focus-visible,
-.live-controls-toggle:focus-visible {
+.live-controls-toggle:focus-visible,
+.live-dark-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+.live-dark-toggle:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 
 .live-title {
@@ -459,7 +466,8 @@
 
   /* Show toggle buttons */
   .live-header-toggle,
-  .live-controls-toggle { display: inline-flex; }
+  .live-controls-toggle,
+  .live-dark-toggle { display: inline-flex; }
 
   /* When collapsed, hide the body */
   .live-header.is-collapsed .live-header-body,
@@ -561,7 +569,8 @@
    * strip. Tap target stays ≥40px (above WCAG 24px minimum, within #1060
    * spirit). The header chart-icon toggle is fully removed on mobile so
    * the gear is the only persistent action button. */
-  .live-controls-toggle {
+  .live-controls-toggle,
+  .live-dark-toggle {
     min-width: 36px; min-height: 36px;
     width: 36px; height: 36px;
     padding: 6px;

--- a/public/live.js
+++ b/public/live.js
@@ -1006,6 +1006,7 @@
           <div class="live-header-critical" data-live-header-critical>
             <span class="live-beacon" aria-label="WebSocket connection beacon"></span>
             <div class="live-stat-pill live-stat-pill--critical"><span id="livePktCount">0</span> pkts</div>
+            <button class="live-dark-toggle" data-live-dark-toggle aria-label="Toggle dark mode">☀️</button>
           </div>
           <!-- #1234: stats row promoted to a direct child of .live-header so
                the counters are always visible inline on mobile (single-row
@@ -1212,6 +1213,17 @@
     }
 
     map.on('zoomend', rescaleMarkers);
+
+    // Dark mode toggle in live-header-critical (top-nav is hidden on mobile /live)
+    const liveDarkToggle = document.querySelector('[data-live-dark-toggle]');
+    if (liveDarkToggle) {
+      liveDarkToggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '🌙' : '☀️';
+      liveDarkToggle.addEventListener('click', () => {
+        const realToggle = document.getElementById('darkModeToggle');
+        if (realToggle && !realToggle.disabled) realToggle.click();
+        liveDarkToggle.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '🌙' : '☀️';
+      });
+    }
 
     // Heat map toggle — persist in localStorage
     const liveHeatEl = document.getElementById('liveHeatToggle');
@@ -3098,9 +3110,13 @@
         document.documentElement.setAttribute('data-theme', 'dark');
         const dt = document.getElementById('darkModeToggle');
         if (dt) { dt.textContent = '🌙'; dt.disabled = true; }
+        const ldt = document.querySelector('[data-live-dark-toggle]');
+        if (ldt) { ldt.textContent = '🌙'; ldt.disabled = true; }
       } else {
         const dt = document.getElementById('darkModeToggle');
         if (dt) dt.disabled = true;
+        const ldt = document.querySelector('[data-live-dark-toggle]');
+        if (ldt) ldt.disabled = true;
       }
       container.classList.add('matrix-theme');
       if (!document.getElementById('matrixScanlines')) {
@@ -3126,10 +3142,14 @@
         localStorage.setItem('meshcore-theme', prevTheme);
         const dt = document.getElementById('darkModeToggle');
         if (dt) { dt.textContent = prevTheme === 'dark' ? '🌙' : '☀️'; dt.disabled = false; }
+        const ldt = document.querySelector('[data-live-dark-toggle]');
+        if (ldt) { ldt.textContent = prevTheme === 'dark' ? '🌙' : '☀️'; ldt.disabled = false; }
         delete container.dataset.matrixPrevTheme;
       } else {
         const dt = document.getElementById('darkModeToggle');
         if (dt) dt.disabled = false;
+        const ldt = document.querySelector('[data-live-dark-toggle]');
+        if (ldt) ldt.disabled = false;
       }
       for (const [key, marker] of Object.entries(nodeMarkers)) {
         if (marker._matrixPrevColor) {


### PR DESCRIPTION
## Summary

- On mobile (≤640px) the top-nav is hidden entirely on `/live` — `#darkModeToggle` inside `.nav-right` was unreachable
- Adds a `☀️`/`🌙` button to the always-visible `live-header-critical` strip (beacon + pkt count row)
- Click delegates to `#darkModeToggle` — `app.js` stays the single owner of all theme logic, no duplication
- Matrix mode disables/enables the live button alongside the top-nav button so both stay in sync

## Test plan

- [ ] Mobile (≤640px) on `/live`: `☀️`/`🌙` button visible in the header strip; tap toggles theme
- [ ] Button icon matches current theme on page load and after each toggle
- [ ] Enable Matrix mode → both `#darkModeToggle` and the live button become disabled (greyed out)
- [ ] Disable Matrix mode → both buttons re-enabled, icons reflect restored theme
- [ ] Desktop: button not visible (hidden via CSS — top-nav toggle is used instead)
- [ ] `≤768px` non-phone breakpoint: button visible and correctly sized (36×36px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)