### PR TITLE
fix(ci): stop cancelling master runs — only cancel stale PR builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

- `cancel-in-progress: true` was silently killing staging deploys whenever a new commit landed on master during an active CI run
- During burst-merge sessions (7 cancelled runs documented in #1395), staging drifted hours behind master with no failure signal (cancelled = grey, not red)
- Fix: evaluate to `true` only for `pull_request` events, so PR branches still drop stale runs but master runs always complete

## Test plan

- [ ] Verify expression evaluates correctly: PRs → `true` (cancel stale), master push → `false` (never cancel), `workflow_dispatch` → `false` (let manual runs complete)
- [ ] Manually trigger: merge 3 PRs in quick succession, confirm all 3 staging deploys complete
- [ ] Confirm no master CI run shows `cancelled` status after the fix

Closes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)