### PR TITLE
fix(live): decouple live animation from VCR.speed — always 1× in LIVE mode

### DIFF
--- a/public/live.js
+++ b/public/live.js
@@ -3231,7 +3231,7 @@
 
     const matrixGreen = '#00ff41';
     const TRAIL_LEN = Math.min(6, bytes.length);
-    const DURATION_MS = 1100 / VCR.speed;
+    const DURATION_MS = VCR.mode === 'REPLAY' ? 1100 / VCR.speed : 1100;
     const CHAR_INTERVAL = 0.06; // spawn a char every 6% of progress
     const charMarkers = [];
     let nextCharAt = CHAR_INTERVAL;
@@ -3363,7 +3363,7 @@
         return;
       }
       const elapsed = now - lastStep;
-      const stepMs = 33 / VCR.speed;
+      const stepMs = VCR.mode === 'REPLAY' ? 33 / VCR.speed : 33;
       if (elapsed >= stepMs) {
         const ticks = Math.min(Math.floor(elapsed / stepMs), 4);
         lastStep = now;


### PR DESCRIPTION
## Summary

- `drawAnimatedLine` and `drawMatrixLine` both used `33 / VCR.speed` and `1100 / VCR.speed` as timing constants
- `VCR.speed` persists in localStorage, so a 4× or 8× replay setting carried into live mode made packet animations run near-instantaneously (8.25ms steps vs 33ms)
- Guard both constants behind `VCR.mode === 'REPLAY'` so live mode always animates at the baseline rate regardless of saved speed

## Test plan

- [ ] Set replay speed to 4×, end replay, reload page → live animation runs at normal speed (~660ms for a full hop animation)
- [ ] Verify replay still respects slow-mo: 0.25× is visibly slower, 4× is faster
- [ ] Verify live animations are unaffected by the stored `live-vcr-speed` localStorage value

Closes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)