### PR TITLE
fix(ingestor): don't stamp timestamp in procIO snapshot on os.Open failure

### DIFF
--- a/cmd/ingestor/stats_file.go
+++ b/cmd/ingestor/stats_file.go
@@ -107,12 +107,12 @@ var readProcSelfIOFn = readProcSelfIO
 // readProcSelfIO parses /proc/self/io. Returns ok=false on non-Linux hosts or
 // any read/parse failure (caller skips the procIO block in that case).
 func readProcSelfIO() procIOSnapshot {
-	out := procIOSnapshot{at: time.Now()}
 	f, err := os.Open("/proc/self/io")
 	if err != nil {
-		return out
+		return procIOSnapshot{}
 	}
 	defer f.Close()
+	out := procIOSnapshot{at: time.Now()}
 	parseProcSelfIOInto(bufio.NewScanner(f), &out)
 	return out
 }

--- a/cmd/ingestor/stats_file_test.go
+++ b/cmd/ingestor/stats_file_test.go
@@ -8,6 +8,37 @@ import (
 	"time"
 )
 
+// TestProcIORate_ZeroValuePrevSuppressesRate guards against the phantom-delta
+// regression from #1169: when os.Open("/proc/self/io") fails, readProcSelfIO
+// now returns a zero-value procIOSnapshot (ok=false, zero time.Time). This
+// asserts procIORate returns nil so no inflated rate spike appears for the
+// next successful read.
+func TestProcIORate_ZeroValuePrevSuppressesRate(t *testing.T) {
+	prev := procIOSnapshot{} // zero-value: ok=false, at=zero
+	cur := procIOSnapshot{
+		at:        time.Now(),
+		readBytes: 1024 * 1024 * 100,
+		ok:        true,
+	}
+	if got := procIORate(prev, cur, "2026-01-01T00:00:00Z"); got != nil {
+		t.Fatalf("expected nil rate when prev is zero-value (os.Open failed), got %+v", got)
+	}
+}
+
+// TestProcIORate_NormalPath asserts two valid snapshots produce a non-nil rate.
+func TestProcIORate_NormalPath(t *testing.T) {
+	base := time.Now()
+	prev := procIOSnapshot{at: base, readBytes: 0, ok: true}
+	cur := procIOSnapshot{at: base.Add(time.Second), readBytes: 1024, ok: true}
+	got := procIORate(prev, cur, "2026-01-01T00:00:01Z")
+	if got == nil {
+		t.Fatal("expected non-nil rate for valid prev/cur pair")
+	}
+	if got.ReadBytesPerSec != 1024.0 {
+		t.Errorf("ReadBytesPerSec: want 1024.0, got %v", got.ReadBytesPerSec)
+	}
+}
+
 // TestStatsFileWriter_PublishesProcIO asserts the ingestor's published
 // stats snapshot includes a `procIO` block with the per-process I/O rate
 // fields required by issue #1120 ("Both ingestor and server").


### PR DESCRIPTION
## Summary

- `readProcSelfIO()` stamped `at=time.Now()` before attempting to open `/proc/self/io`
- On non-Linux hosts or when the kernel file is unavailable, it returned a snapshot with `ok=false` but a fresh timestamp
- The rate calculator used `prevIO.at` for delta computation, so the next successful read produced a phantom rate spike spanning the entire failure interval
- Fix: move the timestamp stamp to after successful `os.Open`, so failed opens return a zero-value snapshot with no timestamp — `procIORate` short-circuits on `prev.ok=false` and returns nil

## Test plan

- [ ] `go test ./...` in `cmd/ingestor` — both new unit tests pass:
  - `TestProcIORate_ZeroValuePrevSuppressesRate` — asserts nil rate when prev is zero-value
  - `TestProcIORate_NormalPath` — asserts correct rate for valid prev/cur pair
- [ ] On Linux: confirm `procIO` block still appears in the stats file after 2 ticks

Closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)