### PR TITLE
feat(server): warn at startup when GOMEMLIMIT < 50% of container memory limit (#1264)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -126,6 +126,7 @@ func main() {
 		default:
 			log.Printf("[memlimit] no soft memory limit set (GOMEMLIMIT unset, packetStore.maxMemoryMB=0); recommend setting one to avoid container OOM-kill")
 		}
+		warnIfMemlimitUnderprovisioned(limit)
 	}
 
 	// Resolve DB path

--- a/cmd/server/memlimit.go
+++ b/cmd/server/memlimit.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"log"
+	"os"
 	"runtime/debug"
+	"strconv"
+	"strings"
 )
+
+// cgroupUnlimitedThreshold is the sentinel above which a cgroup memory value
+// means "no limit". cgroup v1 encodes unlimited as math.MaxInt64 (page-aligned
+// near 1<<63); 1<<62 is a safe upper bound that excludes all real limits while
+// staying well below the unlimited sentinel.
+const cgroupUnlimitedThreshold = int64(1 << 62)
 
 // applyMemoryLimit configures Go's soft memory limit (GOMEMLIMIT).
 //
@@ -29,4 +39,75 @@ func applyMemoryLimit(maxMemoryMB int, envSet bool) (int64, string) {
 	limit := int64(maxMemoryMB) * 1024 * 1024 * 3 / 2
 	debug.SetMemoryLimit(limit)
 	return limit, "derived"
+}
+
+// readCgroupMemoryMBFn is the package-level hook used by
+// warnIfMemlimitUnderprovisioned. Tests override it to inject deterministic
+// cgroup values without needing a Linux kernel with cgroup mounts.
+var readCgroupMemoryMBFn = readCgroupMemoryMB
+
+// readCgroupMemoryMB returns the container's memory limit from cgroup, in MiB.
+// Returns 0 when unavailable (non-Linux, unlimited, or read error).
+func readCgroupMemoryMB() int64 {
+	// cgroup v2: single file, value in bytes or literal "max"
+	if b, err := os.ReadFile("/sys/fs/cgroup/memory.max"); err == nil {
+		s := strings.TrimSpace(string(b))
+		if s != "max" {
+			if v, err := strconv.ParseInt(s, 10, 64); err == nil && v > 0 {
+				return v / (1024 * 1024)
+			}
+		}
+	}
+	// cgroup v1: values near math.MaxInt64 represent "unlimited"
+	if b, err := os.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil {
+		if v, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); err == nil {
+			if v > 0 && v < cgroupUnlimitedThreshold {
+				return v / (1024 * 1024)
+			}
+		}
+	}
+	return 0
+}
+
+// memlimitUnderprovisioned reports whether effectiveMB is less than half of
+// cgroupMB. Extracted for unit testing the comparison boundary.
+func memlimitUnderprovisioned(effectiveMB, cgroupMB int64) bool {
+	return effectiveMB > 0 && cgroupMB > 0 && effectiveMB*2 < cgroupMB
+}
+
+// warnIfMemlimitUnderprovisioned logs a warning when GOMEMLIMIT is below 50%
+// of the container cgroup memory limit, which causes the Go GC to thrash.
+// In one reported incident (#1264) 82% of CPU was GC with a 1536 MiB limit
+// on a 7.7 GB container — all endpoints 3-100x slower until maxMemoryMB was
+// bumped and the process restarted.
+//
+// limitBytes is the value returned by applyMemoryLimit:
+//   - source="derived": the limit we set ourselves (> 0)
+//   - source="env":  0 — we did not touch the runtime; read it back below
+//   - source="none": 0 — no limit set at all; runtime default is math.MaxInt64,
+//     which the >= cgroupUnlimitedThreshold guard below catches and skips
+func warnIfMemlimitUnderprovisioned(limitBytes int64) {
+	cgroupMB := readCgroupMemoryMBFn()
+	if cgroupMB <= 0 {
+		return
+	}
+	effective := limitBytes
+	if effective <= 0 {
+		// Either GOMEMLIMIT was set via env (source="env") or no limit was
+		// configured (source="none"). Read the runtime's current value:
+		// - env case: returns whatever the operator set
+		// - none case: returns math.MaxInt64, caught by the guard below
+		// debug.SetMemoryLimit(-1) leaves the limit unchanged and returns it.
+		effective = debug.SetMemoryLimit(-1)
+	}
+	if effective <= 0 || effective >= cgroupUnlimitedThreshold {
+		return
+	}
+	effectiveMB := effective / (1024 * 1024)
+	if memlimitUnderprovisioned(effectiveMB, cgroupMB) {
+		log.Printf("[memlimit] WARN: GOMEMLIMIT=%d MiB is <50%% of container limit %d MiB — "+
+			"GC may thrash under load; consider bumping packetStore.maxMemoryMB "+
+			"(suggested: ~%d MiB, roughly 2/3 of container limit)",
+			effectiveMB, cgroupMB, cgroupMB*2/3)
+	}
 }

--- a/cmd/server/memlimit_test.go
+++ b/cmd/server/memlimit_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"log"
 	"runtime/debug"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +53,111 @@ func TestApplyMemoryLimit_None(t *testing.T) {
 	}
 	if limit != 0 {
 		t.Fatalf("expected limit=0, got %d", limit)
+	}
+}
+
+func TestMemlimitUnderprovisioned(t *testing.T) {
+	cases := []struct {
+		effective, cgroup int64
+		want              bool
+	}{
+		{512, 1536, true},   // 512*2=1024 < 1536 → underprovisioned
+		{768, 1536, false},  // 768*2=1536 == 1536 → not under (boundary)
+		{1024, 1536, false},
+		{0, 1536, false},    // no effective limit → skip
+		{512, 0, false},     // no cgroup info → skip
+	}
+	for _, c := range cases {
+		got := memlimitUnderprovisioned(c.effective, c.cgroup)
+		if got != c.want {
+			t.Errorf("memlimitUnderprovisioned(%d, %d) = %v, want %v", c.effective, c.cgroup, got, c.want)
+		}
+	}
+}
+
+// captureLog redirects the default logger to a buffer for the duration of f,
+// then restores the previous writer. Returns captured output.
+func captureLog(f func()) string {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+	f()
+	return buf.String()
+}
+
+// TestWarnIfMemlimitUnderprovisioned_EmitsWarning verifies the warning IS
+// logged when the injected cgroup reader reports a container limit more than
+// 2x larger than the effective GOMEMLIMIT.
+func TestWarnIfMemlimitUnderprovisioned_EmitsWarning(t *testing.T) {
+	defer debug.SetMemoryLimit(-1)
+	// Effective: 512 MiB; container: 2048 MiB → 512*2=1024 < 2048 → warn
+	debug.SetMemoryLimit(int64(512) * 1024 * 1024)
+
+	orig := readCgroupMemoryMBFn
+	readCgroupMemoryMBFn = func() int64 { return 2048 }
+	defer func() { readCgroupMemoryMBFn = orig }()
+
+	out := captureLog(func() {
+		warnIfMemlimitUnderprovisioned(int64(512) * 1024 * 1024)
+	})
+	if !strings.Contains(out, "[memlimit] WARN") {
+		t.Errorf("expected warning log, got: %q", out)
+	}
+}
+
+// TestWarnIfMemlimitUnderprovisioned_NoWarnWhenAdequate verifies no warning
+// when GOMEMLIMIT is >= 50% of the container limit.
+func TestWarnIfMemlimitUnderprovisioned_NoWarnWhenAdequate(t *testing.T) {
+	defer debug.SetMemoryLimit(-1)
+	// Effective: 1024 MiB; container: 1536 MiB → 1024*2=2048 >= 1536 → no warn
+	debug.SetMemoryLimit(int64(1024) * 1024 * 1024)
+
+	orig := readCgroupMemoryMBFn
+	readCgroupMemoryMBFn = func() int64 { return 1536 }
+	defer func() { readCgroupMemoryMBFn = orig }()
+
+	out := captureLog(func() {
+		warnIfMemlimitUnderprovisioned(int64(1024) * 1024 * 1024)
+	})
+	if strings.Contains(out, "[memlimit] WARN") {
+		t.Errorf("unexpected warning when limit is adequate: %q", out)
+	}
+}
+
+// TestWarnIfMemlimitUnderprovisioned_NoCgroupNoLog verifies early exit when
+// no cgroup info is available (non-Linux / non-container).
+func TestWarnIfMemlimitUnderprovisioned_NoCgroupNoLog(t *testing.T) {
+	defer debug.SetMemoryLimit(-1)
+	debug.SetMemoryLimit(int64(512) * 1024 * 1024)
+
+	orig := readCgroupMemoryMBFn
+	readCgroupMemoryMBFn = func() int64 { return 0 }
+	defer func() { readCgroupMemoryMBFn = orig }()
+
+	out := captureLog(func() {
+		warnIfMemlimitUnderprovisioned(int64(512) * 1024 * 1024)
+	})
+	if strings.Contains(out, "[memlimit] WARN") {
+		t.Errorf("unexpected warning when cgroup unavailable: %q", out)
+	}
+}
+
+// TestWarnIfMemlimitUnderprovisioned_NoneSource verifies that when no limit
+// was configured (source="none", limitBytes=0), the function reads back
+// math.MaxInt64 from the runtime and skips the warning.
+func TestWarnIfMemlimitUnderprovisioned_NoneSource(t *testing.T) {
+	defer debug.SetMemoryLimit(-1)
+	debug.SetMemoryLimit(int64(1<<63 - 1)) // math.MaxInt64 = "no limit"
+
+	orig := readCgroupMemoryMBFn
+	readCgroupMemoryMBFn = func() int64 { return 2048 }
+	defer func() { readCgroupMemoryMBFn = orig }()
+
+	out := captureLog(func() {
+		warnIfMemlimitUnderprovisioned(0) // source="none" passes limit=0
+	})
+	if strings.Contains(out, "[memlimit] WARN") {
+		t.Errorf("unexpected warning when no limit configured: %q", out)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `readCgroupMemoryMB()` to detect container memory ceiling from cgroup v2 (`/sys/fs/cgroup/memory.max`) and v1 (`/sys/fs/cgroup/memory.limit_in_bytes`)
- Adds `warnIfMemlimitUnderprovisioned()` called once from `main()` after the existing memlimit block — logs a `[memlimit] WARN` at startup if the effective GOMEMLIMIT is below 50% of the container limit
- Works whether the limit was set via `GOMEMLIMIT` env var or derived from `packetStore.maxMemoryMB`
- Adds `readCgroupMemoryMBFn` package-level hook for test injection (same pattern as `readProcSelfIOFn` in the ingestor)

Fixes #1264. In the reported incident, GOMEMLIMIT was 1536 MiB on a 7.7 GB container; GC consumed 82% of CPU and all endpoints were 3–100× slower. This warning fires at startup so operators catch the misconfiguration before it causes an incident.

## Test plan

- [ ] `TestWarnIfMemlimitUnderprovisioned_EmitsWarning` — warning fires when effective < 50% of cgroup
- [ ] `TestWarnIfMemlimitUnderprovisioned_NoWarnWhenAdequate` — no warning at boundary (effective = 1024 MiB, cgroup = 1536 MiB)
- [ ] `TestWarnIfMemlimitUnderprovisioned_NoCgroupNoLog` — silent on non-container hosts
- [ ] `TestWarnIfMemlimitUnderprovisioned_NoneSource` — no warning when `source="none"` (no limit configured, runtime returns math.MaxInt64)
- [ ] `TestMemlimitUnderprovisioned` — boundary table for the comparison helper
- [ ] All existing `TestApplyMemoryLimit_*` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)