### PR TITLE
fix(packets): use route-aware path byte offset for HB column

### DIFF
--- a/public/packets.js
+++ b/public/packets.js
@@ -2009,7 +2009,8 @@
     const groupTypeName = payloadTypeName(p.payload_type);
     const groupTypeClass = payloadTypeColor(p.payload_type);
     const groupSize = p.raw_hex ? Math.floor(p.raw_hex.length / 2) : 0;
-    const groupHashBytes = ((parseInt(p.raw_hex?.slice(2, 4), 16) || 0) >> 6) + 1;
+    const _grpPlOff = getPathLenOffset(p.route_type);
+    const groupHashBytes = ((parseInt(p.raw_hex?.slice(_grpPlOff * 2, _grpPlOff * 2 + 2), 16) || 0) >> 6) + 1;
     const isSingle = p.count <= 1;
     // Channel color highlighting (#271)
     const _grpDecoded = getParsedDecoded(p) || {};
@@ -2038,9 +2039,12 @@
         const typeName = payloadTypeName(c.payload_type);
         const typeClass = payloadTypeColor(c.payload_type);
         const size = c.raw_hex ? Math.floor(c.raw_hex.length / 2) : 0;
-        const childHashBytes = ((parseInt(c.raw_hex?.slice(2, 4), 16) || 0) >> 6) + 1;
-        const childRegion = c.observer_id ? (observerMap.get(c.observer_id)?.iata || '') : '';
         const childPath = getParsedPath(c);
+        const _cPlOff = getPathLenOffset(p.route_type);
+        const childHashBytes = c.raw_hex
+          ? (((parseInt(c.raw_hex.slice(_cPlOff * 2, _cPlOff * 2 + 2), 16) || 0) >> 6) + 1)
+          : (childPath.length > 0 ? childPath[0].length / 2 : 0);
+        const childRegion = c.observer_id ? (observerMap.get(c.observer_id)?.iata || '') : '';
         const childPathStr = renderPath(childPath, c.observer_id);
         const _childHashStripe = _hashStripeStyle(c.hash || p.hash);
         html += `<tr class="group-child" data-id="${c.id}" data-hash="${c.hash || ''}" data-action="select-observation" data-value="${c.id}" data-parent-hash="${p.hash}" data-entry-idx="${entryIdx}" tabindex="0" role="row"${_childHashStripe ? ' style="' + _childHashStripe + '"' : ''}>
@@ -2070,7 +2074,8 @@
     // Channel color highlighting (#271)
     const _chanStyle = window.ChannelColors ? window.ChannelColors.getRowStyle(decoded.type || typeName, decoded.channel) : '';
     const size = p.raw_hex ? Math.floor(p.raw_hex.length / 2) : 0;
-    const hashBytes = ((parseInt(p.raw_hex?.slice(2, 4), 16) || 0) >> 6) + 1;
+    const _flatPlOff = getPathLenOffset(p.route_type);
+    const hashBytes = ((parseInt(p.raw_hex?.slice(_flatPlOff * 2, _flatPlOff * 2 + 2), 16) || 0) >> 6) + 1;
     const pathStr = renderPath(pathHops, p.observer_id);
     const detail = getDetailPreview(decoded);
     const _flatHashStripe = _hashStripeStyle(p.hash);


### PR DESCRIPTION
## Summary

- The **HB** (hash bytes) column in the packet list always read byte 1 of `raw_hex` to compute the hash size
- For TRANSPORT routes (`route_type` 0 or 3), the path_len byte sits at offset 5 — bytes 1–4 are transport codes
- Reading byte 1 for these packets produced the wrong hash size (e.g. `0xBB` → bits 7-6 = `10` → **3** instead of the correct **2**)
- Fix: use `getPathLenOffset(route_type)` at all three render sites (grouped header, grouped children, flat row)
- For grouped children that have no `raw_hex`, fall back to deriving hash size from the path_json hop string lengths

## Test plan

- [ ] Open a TRANSPORT FLOOD packet (`route_type=0`) in the packet list — HB column now shows the correct value (e.g. 2 instead of 3)
- [ ] Verify FLOOD packets (`route_type=1`) still show the correct hash size (byte 1 unchanged for non-transport routes)
- [ ] Expand a grouped packet row and confirm child rows show correct hash size from path_json hop lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)