### PR TITLE
perf(server): TTL-cache /api/stats observations aggregate — eliminate per-request full-table scan (#1460)

### DIFF
--- a/cmd/server/get_store_stats_cache_test.go
+++ b/cmd/server/get_store_stats_cache_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestGetStoreStats_CacheHit verifies that a second call within 30s returns
+// the cached observation counts without re-querying the database.
+func TestGetStoreStats_CacheHit(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	store := srv.store
+
+	store.statsCacheMu.Lock()
+	store.statsCacheTime = time.Now()
+	store.statsLastHour = 42
+	store.statsLast24h = 777
+	store.statsCacheMu.Unlock()
+
+	st, err := store.GetStoreStats()
+	if err != nil {
+		t.Fatalf("GetStoreStats: %v", err)
+	}
+	if st.PacketsLastHour != 42 {
+		t.Errorf("cache hit: PacketsLastHour want 42 got %d", st.PacketsLastHour)
+	}
+	if st.PacketsLast24h != 777 {
+		t.Errorf("cache hit: PacketsLast24h want 777 got %d", st.PacketsLast24h)
+	}
+}
+
+// TestGetStoreStats_CacheExpiry verifies that a cache older than 30s is
+// discarded and the database query re-runs to refresh the values.
+func TestGetStoreStats_CacheExpiry(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	store := srv.store
+
+	store.statsCacheMu.Lock()
+	store.statsCacheTime = time.Now().Add(-35 * time.Second)
+	store.statsLastHour = 9999
+	store.statsLast24h = 9999
+	store.statsCacheMu.Unlock()
+
+	st, err := store.GetStoreStats()
+	if err != nil {
+		t.Fatalf("GetStoreStats: %v", err)
+	}
+	if st.PacketsLastHour == 9999 || st.PacketsLast24h == 9999 {
+		t.Errorf("stale cache not expired: got PacketsLastHour=%d PacketsLast24h=%d — DB values expected, not sentinel",
+			st.PacketsLastHour, st.PacketsLast24h)
+	}
+
+	store.statsCacheMu.Lock()
+	age := time.Since(store.statsCacheTime)
+	store.statsCacheMu.Unlock()
+	if age > 5*time.Second {
+		t.Errorf("cache not refreshed after expiry: statsCacheTime age=%v", age)
+	}
+}
+
+// TestGetStoreStats_CacheConcurrentReaders verifies that 100 concurrent
+// callers produce no data race on the stats cache fields.
+// Run with: go test -race ./... -run TestGetStoreStats_CacheConcurrentReaders
+func TestGetStoreStats_CacheConcurrentReaders(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	store := srv.store
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 100)
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := store.GetStoreStats(); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent GetStoreStats: %v", err)
+	}
+}

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -383,6 +383,14 @@ type PacketStore struct {
 	evicted          int64          // total packets evicted
 	trackedBytes     int64          // running total of estimated packet store memory
 	memoryEstimator  func() float64 // injectable for tests; nil = use runtime.ReadMemStats (stats only)
+
+	// Short-lived cache for the observations aggregate in GetStoreStats (30s TTL).
+	// Avoids a per-/api/stats full-table scan; values accurate to ~30s which is
+	// sufficient for dashboard display.
+	statsCacheMu   sync.Mutex
+	statsCacheTime time.Time
+	statsLastHour  int
+	statsLast24h   int
 }
 
 // Precomputed distance records for fast analytics aggregation.
@@ -1627,11 +1635,24 @@ func (s *PacketStore) GetStoreStats() (*Stats, error) {
 	oneHourAgo := time.Now().Add(-1 * time.Hour).Unix()
 	oneDayAgo := time.Now().Add(-24 * time.Hour).Unix()
 
-	// Run node/observer counts and observation counts concurrently (2 queries instead of 5).
+	// Serve observation counts from cache if fresh (avoids per-request full-table scan).
+	var obsFromCache bool
+	s.statsCacheMu.Lock()
+	if !s.statsCacheTime.IsZero() && time.Since(s.statsCacheTime) < 30*time.Second {
+		st.PacketsLastHour = s.statsLastHour
+		st.PacketsLast24h = s.statsLast24h
+		obsFromCache = true
+	}
+	s.statsCacheMu.Unlock()
+
+	// Run node/observer counts and (if cache miss) observation counts concurrently.
 	var wg sync.WaitGroup
 	var nodeErr, obsErr error
 
-	wg.Add(2)
+	wg.Add(1)
+	if !obsFromCache {
+		wg.Add(1)
+	}
 	go func() {
 		defer wg.Done()
 		nodeErr = s.db.conn.QueryRow(
@@ -1642,16 +1663,25 @@ func (s *PacketStore) GetStoreStats() (*Stats, error) {
 			sevenDaysAgo,
 		).Scan(&st.TotalNodes, &st.TotalNodesAllTime, &st.TotalObservers)
 	}()
-	go func() {
-		defer wg.Done()
-		obsErr = s.db.conn.QueryRow(
-			`SELECT
-				COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0),
-				COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0)
-			FROM observations WHERE timestamp > ?`,
-			oneHourAgo, oneDayAgo, oneDayAgo,
-		).Scan(&st.PacketsLastHour, &st.PacketsLast24h)
-	}()
+	if !obsFromCache {
+		go func() {
+			defer wg.Done()
+			obsErr = s.db.conn.QueryRow(
+				`SELECT
+					COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0),
+					COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0)
+				FROM observations WHERE timestamp > ?`,
+				oneHourAgo, oneDayAgo, oneDayAgo,
+			).Scan(&st.PacketsLastHour, &st.PacketsLast24h)
+			if obsErr == nil {
+				s.statsCacheMu.Lock()
+				s.statsLastHour = st.PacketsLastHour
+				s.statsLast24h = st.PacketsLast24h
+				s.statsCacheTime = time.Now()
+				s.statsCacheMu.Unlock()
+			}
+		}()
+	}
 	wg.Wait()
 
 	if nodeErr != nil {


### PR DESCRIPTION
## Problem

`GetStoreStats` ran a `SUM(CASE WHEN timestamp > ?)` over the full `observations` table on **every** `/api/stats` call. The staging pprof analysis (#1460) identified this as rank #9 CPU consumer: `GetStoreStats.func2` at 920ms cumulative = ~10% of all server CPU.

The query:
```sql
SELECT
  COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0),
  COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0)
FROM observations WHERE timestamp > ?
```
scans ~1.9M rows each time `/api/stats` is polled (every 15s from the dashboard).

## Fix

Add a **30-second TTL cache** on `PacketStore` for `PacketsLastHour` and `PacketsLast24h`:
- Cache hit → skip the observations goroutine entirely, use stored values
- Cache miss → run the query, update cache with result
- The node/observer `COUNT(*)` query is unchanged and always runs fresh

The hour/24h counts are display-only values; 30s accuracy is sufficient.

## Changes

`cmd/server/store.go`:
- 4 new fields on `PacketStore`: `statsCacheMu sync.Mutex`, `statsCacheTime time.Time`, `statsLastHour int`, `statsLast24h int`
- `GetStoreStats`: check cache before launching goroutines; conditional `wg.Add`; update cache after successful query

Builds clean. No tests changed.

Closes #1460 (P1#1 from staging CPU profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)