### PR TITLE
Fix must-fix items from #1490 post-merge review (Issue #1514)

### DIFF
--- a/public/live.js
+++ b/public/live.js
@@ -1262,10 +1262,11 @@
       try {
         updateAnimCanvas();
       } finally {
+        const nextMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
         if (_dprMedia) {
           _dprMedia.removeEventListener('change', _dprChangeHandler);
         }
-        _dprMedia = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+        _dprMedia = nextMedia;
         _dprMedia.addEventListener('change', _dprChangeHandler);
       }
     };
@@ -3686,12 +3687,12 @@
     if (!pathsLayer) return;
 
     const contrail = L.polyline([anim.from, anim.to], {
-      // pane: 'animationsPane', // Uncomment if you created the custom pane in the previous step
+      pane: 'animationsPane',
       color: anim.contrailColor, weight: 6, opacity: anim.opacity * 0.2, lineCap: 'round'
     }).addTo(pathsLayer);
 
     const line = L.polyline([anim.from, anim.to], {
-      // pane: 'animationsPane', // Uncomment if you created the custom pane in the previous step
+      pane: 'animationsPane',
       color: anim.lineColor, weight: anim.isDashed ? 1.5 : 2, opacity: anim.opacity,
       lineCap: 'round', dashArray: anim.isDashed ? '4 6' : null
     }).addTo(pathsLayer);


### PR DESCRIPTION
This addresses the critical feedback items from the canvas animation pull request review:

1. Fix DPR-change listener brittleness in `live.js` Construct the new `MediaQueryList` instance before removing the old event listener. This prevents a race condition where a synchronous DPR re-entry could occur between the removal and the re-add, permanently dropping the handler.

2. Fix stacking context for fading trails Uncommented `pane: 'animationsPane'` inside `createFadingLeafletLine()`. Fading leaflet lines were incorrectly falling back to the default `overlayPane` (z=400), rendering underneath the static node markers. They now correctly render on the new custom canvas `animationsPane` (z=625) for consistent stacking.

Resolves "Must-fix carryover" items from #1514.