### PR TITLE
ci: bump Go test timeout 15m -> 20m (server + ingestor)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           go build .
           # -race gates PR #1208's atomic.Pointer migration: the race-detector
           # is what makes path_inspect_atomic_race_test.go actually assert.
-          go test -timeout 15m -race -coverprofile=server-coverage.out ./... 2>&1 | tee server-test.log
+          go test -timeout 20m -race -coverprofile=server-coverage.out ./... 2>&1 | tee server-test.log
           echo "--- Go Server Coverage ---"
           go tool cover -func=server-coverage.out | tail -1
 
@@ -65,7 +65,7 @@ jobs:
           set -e -o pipefail
           cd cmd/ingestor
           go build .
-          go test -timeout 15m -coverprofile=ingestor-coverage.out ./... 2>&1 | tee ingestor-test.log
+          go test -timeout 20m -coverprofile=ingestor-coverage.out ./... 2>&1 | tee ingestor-test.log
           echo "--- Go Ingestor Coverage ---"
           go tool cover -func=ingestor-coverage.out | tail -1
 


### PR DESCRIPTION
## Problem

The server Go suite runs ~13–15m against a **15m** `go test -timeout`, so on slower CI runners it intermittently hits `panic: test timed out after 15m0s` (`cmd/server`, e.g. `db_test.go`) — false-red CI that a plain rerun clears. Observed on PR #1728 (15m25s on the passing attempt — right at the ceiling).

## Fix

Bump both `go test` invocations (`cmd/server` and `cmd/ingestor`) from `-timeout 15m` to `-timeout 20m` for headroom. No test or application code changes — CI workflow only.

## Verification

Workflow-only change; this PR's own CI is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
